### PR TITLE
Port to windows

### DIFF
--- a/pkg/filesystem/BUILD.bazel
+++ b/pkg/filesystem/BUILD.bazel
@@ -6,15 +6,26 @@ go_library(
         "directory.go",
         "file.go",
         "file_info.go",
-        "local_directory.go",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:windows_amd64": [
+            "local_directory_windows.go",
+            "windows_junction.go",
+        ],
+        "//conditions:default": [
+            "local_directory_unix.go",
+        ],
+    }),
     importpath = "github.com/buildbarn/bb-storage/pkg/filesystem",
     visibility = ["//visibility:public"],
     deps = [
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
-        "@org_golang_x_sys//unix:go_default_library",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:windows_amd64": [],
+        "//conditions:default": [
+            "@org_golang_x_sys//unix:go_default_library",
+        ],
+    }),
 )
 
 go_test(

--- a/pkg/filesystem/local_directory_unix.go
+++ b/pkg/filesystem/local_directory_unix.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package filesystem
 
 import (

--- a/pkg/filesystem/local_directory_windows.go
+++ b/pkg/filesystem/local_directory_windows.go
@@ -1,0 +1,254 @@
+// +build windows
+
+package filesystem
+
+import (
+	"errors"
+	"internal/syscall/windows"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const uncPrefix = `\\?\`
+
+type localDirectory struct {
+	longAbsPath string
+}
+
+func validateFilename(name string) error {
+	if name == "" || name == "." || name == ".." ||
+		strings.ContainsRune(name, '/') || strings.ContainsRune(name, '\\') {
+		return status.Errorf(codes.InvalidArgument, "Invalid filename: %#v", name)
+	}
+	return nil
+}
+
+func fileModeToFileType(mode os.FileMode) FileType {
+	var fileType FileType
+	if mode.IsDir() {
+		fileType = FileTypeDirectory
+	} else if mode&os.ModeSymlink != 0 {
+		fileType = FileTypeSymlink
+	} else if mode.IsRegular() {
+		// Can't distinguish between executable or not, choose one.
+		// TODO: Does executable help in case running Wine on Linux
+		fileType = FileTypeExecutableFile
+	} else {
+		fileType = FileTypeOther
+	}
+	return fileType
+}
+
+// NewLocalDirectory creates a directory handle that corresponds to a
+// local path on the system.
+func NewLocalDirectory(path string) (Directory, error) {
+	path = strings.ReplaceAll(path, "/", string(os.PathSeparator))
+	longAbsPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.HasPrefix(longAbsPath, uncPrefix) {
+		longAbsPath = uncPrefix + longAbsPath
+	}
+	return newLocalDirectoryLongAbsPath(longAbsPath)
+}
+
+func newLocalDirectoryLongAbsPath(longAbsPath string) (Directory, error) {
+	fileInfo, err := os.Lstat(longAbsPath)
+	if err != nil {
+		return nil, err
+	}
+	if !fileInfo.IsDir() {
+		return nil, syscall.ENOTDIR
+	}
+	d := &localDirectory{
+		longAbsPath: longAbsPath,
+	}
+	return d, nil
+}
+
+func (d *localDirectory) validateFilenameAndJoin(name string) (string, error) {
+	if err := validateFilename(name); err != nil {
+		return "", err
+	}
+	return filepath.Join(d.longAbsPath, name), nil
+}
+
+func (d *localDirectory) Enter(name string) (Directory, error) {
+	fullPath, err := d.validateFilenameAndJoin(name)
+	if err != nil {
+		return nil, err
+	}
+	return newLocalDirectoryLongAbsPath(fullPath)
+}
+
+func (d *localDirectory) Close() error {
+	return nil
+}
+
+func (d *localDirectory) Link(oldName string, newDirectory Directory, newName string) error {
+	fullOldPath, err := d.validateFilenameAndJoin(oldName)
+	if err != nil {
+		return err
+	}
+
+	d2, ok := newDirectory.(*localDirectory)
+	if !ok {
+		return errors.New("Source and target directory have different types")
+	}
+	fullNewPath, err := d2.validateFilenameAndJoin(newName)
+	if err != nil {
+		return err
+	}
+
+	return os.Link(fullOldPath, fullNewPath)
+}
+
+func (d *localDirectory) Lstat(name string) (FileInfo, error) {
+	fullPath, err := d.validateFilenameAndJoin(name)
+	if err != nil {
+		return FileInfo{}, err
+	}
+
+	fileInfo, err := os.Lstat(fullPath)
+	if err != nil {
+		return FileInfo{}, err
+	}
+	fileType := fileModeToFileType(fileInfo.Mode())
+	return NewFileInfo(name, fileType), nil
+}
+
+func (d *localDirectory) Mkdir(name string, perm os.FileMode) error {
+	fullPath, err := d.validateFilenameAndJoin(name)
+	if err != nil {
+		return err
+	}
+
+	err = os.Mkdir(fullPath, perm)
+	if err != nil {
+		if fileInfo, err2 := os.Stat(fullPath); err2 == nil && fileInfo.IsDir() {
+			// Already exists, possibly with other casing.
+			return nil
+		}
+	}
+	return err
+}
+
+func (d *localDirectory) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
+	fullPath, err := d.validateFilenameAndJoin(name)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := os.OpenFile(fullPath, flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	return f, nil
+}
+
+func (d *localDirectory) ReadDir() ([]FileInfo, error) {
+	osFileInfoList, err := ioutil.ReadDir(d.longAbsPath)
+	if err != nil {
+		return nil, err
+	}
+	fileInfoList := make([]FileInfo, len(osFileInfoList))
+	for i, osFileInfo := range osFileInfoList {
+		fileType := fileModeToFileType(osFileInfo.Mode())
+		fileInfoList[i] = NewFileInfo(osFileInfo.Name(), fileType)
+	}
+	return fileInfoList, nil
+}
+
+func (d *localDirectory) Readlink(name string) (string, error) {
+	fullPath, err := d.validateFilenameAndJoin(name)
+	if err != nil {
+		return "", err
+	}
+	windowsLink, err := os.Readlink(fullPath)
+	if err != nil {
+		if errPath, ok := err.(*os.PathError); ok {
+			if errWin, ok := errPath.Err.(syscall.Errno); ok && errWin == 0x1126 { // ERROR_NOT_A_REPARSE_POINT
+				// TODO: Should this be translated? The tests are currently expecting syscall.EINVAL.
+				return "", syscall.EINVAL
+			}
+		}
+		return "", err
+	}
+	windowsLink = strings.TrimPrefix(windowsLink, uncPrefix)
+	posixLink := strings.ReplaceAll(windowsLink, string(os.PathSeparator), "/")
+	return posixLink, nil
+}
+
+func retryRemoveOnSharingViolation(op func(p string) error, path string) error {
+	var err error
+	for i := 0; i < 20; i++ {
+		err = op(path)
+		if err == nil {
+			break
+		} else if err == windows.ERROR_SHARING_VIOLATION {
+			// Retry
+			log.Print("Retrying to remove ", path, ": ", err)
+			time.Sleep(100 * time.Millisecond)
+		} else {
+			// Unknown error
+			break
+		}
+	}
+	return err
+}
+func (d *localDirectory) Remove(name string) error {
+	fullPath, err := d.validateFilenameAndJoin(name)
+	if err != nil {
+		return err
+	}
+	return retryRemoveOnSharingViolation(os.Remove, fullPath)
+}
+
+func (d *localDirectory) RemoveAllChildren() error {
+	children, err := d.ReadDir()
+	if err != nil {
+		return err
+	}
+	for _, child := range children {
+		name := child.Name()
+		fullPath := filepath.Join(d.longAbsPath, name)
+		err := retryRemoveOnSharingViolation(os.RemoveAll, fullPath)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (d *localDirectory) RemoveAll(name string) error {
+	fullPath, err := d.validateFilenameAndJoin(name)
+	if err != nil {
+		return err
+	}
+	return retryRemoveOnSharingViolation(os.RemoveAll, fullPath)
+}
+
+func (d *localDirectory) Symlink(oldName string, newName string) error {
+	fullNewPath, err := d.validateFilenameAndJoin(newName)
+	if err != nil {
+		return err
+	}
+	// Symlinking on Windows requires raised privileges. Use junctions instead.
+	// os.Symlink(oldName, fullNewPath)
+	var absTarget string
+	if filepath.IsAbs(oldName) {
+		absTarget = oldName
+	} else {
+		absTarget = filepath.Join(d.longAbsPath, oldName)
+	}
+	return MakeDirectoryJunction(fullNewPath, absTarget)
+}

--- a/pkg/filesystem/windows_junction.go
+++ b/pkg/filesystem/windows_junction.go
@@ -1,0 +1,78 @@
+// Inspired by
+// http://www.flexhex.com/docs/articles/hard-links.phtml
+// https://golang.org/src/os/os_windows_test.go
+// https://gist.github.com/Perlmint/f9f0e37db163dd69317d
+
+// +build windows
+
+package filesystem
+
+import (
+	"internal/syscall/windows"
+	"os"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+type reparseDataBuffer struct {
+	header windows.REPARSE_DATA_BUFFER_HEADER
+	data   [syscall.MAXIMUM_REPARSE_DATA_BUFFER_SIZE]byte
+}
+
+const (
+	// The size of .PathBuffer when reparseDataBufferdata is reinterpreted to windows.MountPointReparseBuffer
+	pathBufferByteSize = syscall.MAXIMUM_REPARSE_DATA_BUFFER_SIZE - unsafe.Offsetof(windows.MountPointReparseBuffer{}.PathBuffer)
+)
+
+func newJunctionReparseDataBuffer(targetAbsolutePath string) (reparseDataBuffer, uint32) {
+	var junctionInfo reparseDataBuffer
+	junctionData := (*windows.MountPointReparseBuffer)(unsafe.Pointer(&junctionInfo.data[0]))
+
+	if !strings.HasPrefix(targetAbsolutePath, `\\?\`) {
+		targetAbsolutePath = `\\?\` + targetAbsolutePath
+	}
+	substituteName := syscall.StringToUTF16(targetAbsolutePath)
+	// Skip printName to leave more buffer space for potential long targetAbsolutePath
+	printName := syscall.StringToUTF16("") // targetAbsolutePath
+
+	// Skip the terminating NUL in the length, but copy it to the buffer
+	var pathBuf []uint16
+	junctionData.SubstituteNameOffset = uint16(len(pathBuf) * 2)
+	junctionData.SubstituteNameLength = uint16((len(substituteName) - 1) * 2) // Exclude the NUL terminator
+	pathBuf = append(pathBuf, substituteName...)                              // Include the NUL terminator
+	junctionData.PrintNameOffset = uint16(len(pathBuf) * 2)
+	junctionData.PrintNameLength = uint16((len(printName) - 1) * 2) // Exclude the NUL terminator
+	pathBuf = append(pathBuf, printName...)                         // Include the NUL terminator
+	copy((*[pathBufferByteSize / 2]uint16)(unsafe.Pointer(&junctionData.PathBuffer[0]))[:], pathBuf)
+
+	junctionInfo.header.ReparseTag = windows.IO_REPARSE_TAG_MOUNT_POINT
+	junctionInfo.header.ReparseDataLength = uint16(unsafe.Offsetof(junctionData.PathBuffer)) + uint16(len(pathBuf)*2)
+	junctionInfoLen := uint32(unsafe.Offsetof(junctionInfo.data)) + uint32(junctionInfo.header.ReparseDataLength)
+	return junctionInfo, junctionInfoLen
+}
+
+func MakeDirectoryJunction(link, targetAbsolutePath string) error {
+	junctionInfo, junctionInfoLen := newJunctionReparseDataBuffer(targetAbsolutePath)
+
+	err := os.Mkdir(link, 0777)
+	if err != nil {
+		return err
+	}
+	linkPtr := syscall.StringToUTF16Ptr(link)
+	hlink, err := syscall.CreateFile(linkPtr, syscall.GENERIC_WRITE,
+		syscall.FILE_SHARE_READ|syscall.FILE_SHARE_WRITE, nil, syscall.OPEN_EXISTING,
+		syscall.FILE_FLAG_OPEN_REPARSE_POINT|syscall.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	if err != nil {
+		return err
+	}
+	defer syscall.CloseHandle(hlink)
+
+	var bytesReturned uint32
+	err = syscall.DeviceIoControl(hlink, windows.FSCTL_SET_REPARSE_POINT,
+		(*byte)(unsafe.Pointer(&junctionInfo)), junctionInfoLen, nil, 0, &bytesReturned, nil)
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/pkg/util/digest.go
+++ b/pkg/util/digest.go
@@ -160,6 +160,9 @@ const (
 	// DigestKeyWithInstance lets Digest.GetKey() return a key
 	// that includes the hash, size and instance name.
 	DigestKeyWithInstance
+	// DigestKeyShort lets Digest.GetKey() return a short key
+	// made from parts of the hash.
+	DigestKeyShort
 )
 
 // GetKey generates a string representation of the digest object that
@@ -170,6 +173,8 @@ func (d *Digest) GetKey(format DigestKeyFormat) string {
 		return fmt.Sprintf("%s-%d", d.partialDigest.Hash, d.partialDigest.SizeBytes)
 	case DigestKeyWithInstance:
 		return fmt.Sprintf("%s-%d-%s", d.partialDigest.Hash, d.partialDigest.SizeBytes, d.instance)
+	case DigestKeyShort:
+		return d.partialDigest.Hash[:7]
 	default:
 		log.Fatal("Invalid digest key format")
 		return ""


### PR DESCRIPTION
This change ports pkg/filesystem/local_directory.go to Windows
    
To handle long paths, the paths stored in UNC format by using the prefix \\?\.

When removing files and directories, a retry sequence has been implemented to avoid problems with anti virus programs locking files.

This is part of buildbarn/bb-remote-execution#7