### PR TITLE
Add a Google Cloud Storage backend for Buildbarn.

### DIFF
--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -108,3 +108,51 @@ def bb_storage_go_dependencies():
         strip_prefix = "testify-1.3.0",
         urls = ["https://github.com/stretchr/testify/archive/v1.3.0.tar.gz"],
     )
+
+    go_repository(
+      name = "com_google_cloud_go",
+      importpath = "cloud.google.com/go",
+      vcs = "git",
+      remote = "https://github.com/googleapis/google-cloud-go",
+      tag = "v0.37.4",
+    )
+  
+    go_repository(
+        name = "org_golang_x_oauth2",
+        importpath = "golang.org/x/oauth2",
+        vcs = "git",
+        remote = "https://github.com/golang/oauth2",
+        commit = "9f3314589c9a9136388751d9adae6b0ed400978a",
+    )
+
+    go_repository(
+        name = "org_golang_google_api",
+        importpath = "google.golang.org/api",
+        strip_prefix = "google-api-go-client-0.4.0",
+        sha256 = "b3ccb1714d7f60ecbb42882b68a2da1ee3a721087fa5b22c518156ab8f7e1a12",
+        urls = ["https://github.com/googleapis/google-api-go-client/archive/v0.4.0.zip"],
+    )
+
+    go_repository(
+        name = "com_github_googleapis_gax_go",
+        importpath = "github.com/googleapis/gax-go",
+        tag = "v2.0.4",
+    )
+
+    go_repository(
+        name = "io_opencensus_go",
+        importpath = "go.opencensus.io",
+        sha256 = "839fb798c5034805884c4c6632f1e959b04edaf0c34fc17fd8f617b39af91d79",
+        strip_prefix = "opencensus-go-0.21.0",
+        urls = ["https://github.com/census-instrumentation/opencensus-go/archive/v0.21.0.zip"],
+
+    )
+    
+    go_repository(
+        name = "com_github_hashicorp_golang_lru",
+        importpath = "github.com/hashicorp/golang-lru",
+        sha256 = "db5fb365252d34390618905a43f444a58567029a74f16a9ee077c1b37b9fd007",
+        strip_prefix = "golang-lru-0.5.1",
+        urls = ["https://github.com/hashicorp/golang-lru/archive/v0.5.1.zip"],
+
+    )

--- a/pkg/blobstore/BUILD.bazel
+++ b/pkg/blobstore/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "blob_access.go",
         "content_addressable_storage_blob_access.go",
         "error_blob_access.go",
+        "gcs_blob_access.go",
         "merkle_blob_access.go",
         "metrics_blob_access.go",
         "redis_blob_access.go",
@@ -32,6 +33,9 @@ go_library(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_x_net//context/ctxhttp:go_default_library",
+        "@com_google_cloud_go//storage:go_default_library",
+        "@org_golang_x_oauth2//google:go_default_library",
+        "@org_golang_google_api//option:go_default_library",
     ],
 )
 

--- a/pkg/blobstore/gcs_blob_access.go
+++ b/pkg/blobstore/gcs_blob_access.go
@@ -1,0 +1,107 @@
+package blobstore
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"cloud.google.com/go/storage"
+	"github.com/buildbarn/bb-storage/pkg/util"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/option"
+)
+
+type gcs struct {
+	c             *storage.Client
+	bucket        string
+	keyPrefix     string
+	blobKeyFormat util.DigestKeyFormat
+}
+
+// NewGCS creates a new GCS BlobAccess that uses the provide GCS bucket as its
+// backing store.
+func NewGCS(ctx context.Context, bucketName, keyPrefix string, blobKeyFormat util.DigestKeyFormat, authFile string) (BlobAccess, error) {
+	var creds *google.Credentials
+	if authFile == "" {
+		var err error
+		creds, err = google.FindDefaultCredentials(ctx, storage.ScopeReadWrite)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		data, err := ioutil.ReadFile(authFile)
+		if err != nil {
+			return nil, err
+		}
+		creds, err = google.CredentialsFromJSON(ctx, data, storage.ScopeReadWrite)
+		if err != nil {
+			return nil, err
+		}
+	}
+	client, err := storage.NewClient(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+	return &gcs{
+		c:             client,
+		keyPrefix:     keyPrefix,
+		bucket:        bucketName,
+		blobKeyFormat: blobKeyFormat,
+	}, nil
+}
+
+// Get fetches the object referenced by digest.
+func (g *gcs) Get(ctx context.Context, digest *util.Digest) (int64, io.ReadCloser, error) {
+	o := g.get(digest)
+	a, err := o.Attrs(ctx)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get %q: %v", digest, err)
+	}
+	r, err := o.NewReader(ctx)
+	if err != nil {
+		return 0, nil, err
+	}
+	return a.Size, r, nil
+}
+
+// Put uploads the object referenced by digest.
+func (g *gcs) Put(ctx context.Context, digest *util.Digest, sizeBytes int64, r io.ReadCloser) error {
+	defer r.Close()
+	w := g.get(digest).NewWriter(ctx)
+	if _, err := io.Copy(w, r); err != nil {
+		return err
+	}
+	if err := w.Close(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete deletes the object referenced by digest.
+func (g *gcs) Delete(ctx context.Context, digest *util.Digest) error {
+	return g.get(digest).Delete(ctx)
+}
+
+// FindMissing validates the existence of digests.
+func (g *gcs) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	var missing []*util.Digest
+	for _, digest := range digests {
+		_, err := g.get(digest).Attrs(ctx)
+		switch {
+		case err == storage.ErrObjectNotExist:
+			missing = append(missing, digest)
+		case err != nil:
+			return nil, err
+		}
+	}
+	return missing, nil
+}
+
+func (g *gcs) getKey(digest *util.Digest) string {
+	return g.keyPrefix + digest.GetKey(g.blobKeyFormat)
+}
+
+func (g *gcs) get(digest *util.Digest) *storage.ObjectHandle {
+	return g.c.Bucket(g.bucket).Object(g.getKey(digest))
+}

--- a/pkg/proto/blobstore/blobstore.proto
+++ b/pkg/proto/blobstore/blobstore.proto
@@ -42,6 +42,9 @@ message BlobAccessConfiguration {
         // Fan out requests across multiple storage backends to spread
         // out load.
         ShardingBlobAccessConfiguration sharding = 9;
+
+        // Read objects from/write objects to an GCS bucket.
+        GCSBlobAccessConfiguration gcs = 10;
     }
 }
 
@@ -158,4 +161,15 @@ message SizeDistinguishingeBlobAccessConfiguration {
 
     // Maximum size of blobs read from/written to the backend for small blobs.
     int64 cutoff_size_bytes = 3;
+}
+
+message GCSBlobAccessConfiguration {
+       // Name of the GCS bucket.
+       string bucket = 1;
+   
+       // Prefix for keys, e.g. 'bazel_cas/'.
+       string key_prefix = 2;
+
+       // Auth JWT location.
+       string auth = 3; 
 }


### PR DESCRIPTION
This backend requires auth to be provided via config file (JWT token) or will try to use google default credentials.

Example config:

content_addressable_storage {
  gcs {
    bucket: "<mybucket>"
    key_prefix: "prefix/path"
    auth: "./jwt.json"
  }
}
action_cache {
  gcs {
    bucket: "<mybucket>"
    key_prefix: "prefix/other_path"
    auth: "./jwt.json"
  }
}
