### PR TITLE
Split ContentAddressableStorage interface into reader and writer

### DIFF
--- a/pkg/cas/content_addressable_storage.go
+++ b/pkg/cas/content_addressable_storage.go
@@ -12,13 +12,20 @@ import (
 // ContentAddressableStorage provides typed access to a Bazel Content
 // Addressable Storage (CAS).
 type ContentAddressableStorage interface {
+	ContentAddressableStorageReader
+	ContentAddressableStorageWriter
+}
+
+type ContentAddressableStorageReader interface {
 	GetAction(ctx context.Context, digest *util.Digest) (*remoteexecution.Action, error)
 	GetCommand(ctx context.Context, digest *util.Digest) (*remoteexecution.Command, error)
 	GetDirectory(ctx context.Context, digest *util.Digest) (*remoteexecution.Directory, error)
 	GetFile(ctx context.Context, digest *util.Digest, directory filesystem.Directory, name string, isExecutable bool) error
 	GetTree(ctx context.Context, digest *util.Digest) (*remoteexecution.Tree, error)
 	GetUncachedActionResult(ctx context.Context, digest *util.Digest) (*cas_proto.UncachedActionResult, error)
+}
 
+type ContentAddressableStorageWriter interface {
 	PutFile(ctx context.Context, directory filesystem.Directory, name string, parentDigest *util.Digest) (*util.Digest, error)
 	PutLog(ctx context.Context, log []byte, parentDigest *util.Digest) (*util.Digest, error)
 	PutTree(ctx context.Context, tree *remoteexecution.Tree, parentDigest *util.Digest) (*util.Digest, error)


### PR DESCRIPTION
It is possible to split the `ContentAddressableStorage` interface into a reader and a writer. `ReadWriteDecouplingContentAddressableStorage` already exists and is using one reader and one writer, so this split is a natural refactoring.