### PR TITLE
Detect destructive circular cache config change

### DIFF
--- a/pkg/blobstore/circular/file_state_store.go
+++ b/pkg/blobstore/circular/file_state_store.go
@@ -24,6 +24,10 @@ func NewFileStateStore(file ReadWriterAt, dataSize uint64) (StateStore, error) {
 		if readCursor <= writeCursor {
 			cursors.Read = readCursor
 			cursors.Write = writeCursor
+			if cursors.Read+dataSize < cursors.Write {
+				// Invalidate data that is about to be overwritten if dataSize has changed.
+				cursors.Read = cursors.Write - dataSize
+			}
 		}
 	} else if err != io.EOF {
 		return nil, err

--- a/pkg/blobstore/configuration/create_blob_access.go
+++ b/pkg/blobstore/configuration/create_blob_access.go
@@ -117,7 +117,10 @@ func createBlobAccess(configuration *pb.BlobAccessConfiguration, storageType str
 				return offsetStore, nil
 			})
 		}
-		stateStore, err := circular.NewFileStateStore(stateFile, backend.Circular.DataFileSizeBytes)
+		stateStore, err := circular.NewFileStateStore(
+			stateFile,
+			backend.Circular.DataFileSizeBytes,
+			backend.Circular.OffsetFileSizeBytes)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Avoid the user getting surprised that the cache gets totally trashed when enlarging the cache. Error out instead so the user understands the consequence.