### PR TITLE
Set additional Redis configs

### DIFF
--- a/pkg/blobstore/configuration/create_blob_access.go
+++ b/pkg/blobstore/configuration/create_blob_access.go
@@ -21,10 +21,12 @@ import (
 
 	"gocloud.dev/blob"
 	"gocloud.dev/blob/azureblob"
+
 	// Although not explicitly used here, we want to support a file blob
 	// backend for debug.
 	_ "gocloud.dev/blob/fileblob"
 	"gocloud.dev/blob/gcsblob"
+
 	// Same thing for in-memory blob storage.
 	_ "gocloud.dev/blob/memblob"
 	"gocloud.dev/blob/s3blob"
@@ -218,6 +220,7 @@ func createBlobAccess(configuration *pb.BlobAccessConfiguration, storageType str
 		}
 	case *pb.BlobAccessConfiguration_Redis:
 		backendType = "redis"
+		setRedisConfiguration()
 		implementation = blobstore.NewRedisBlobAccess(
 			redis.NewClient(
 				&redis.Options{
@@ -275,4 +278,41 @@ func createBlobAccess(configuration *pb.BlobAccessConfiguration, storageType str
 		return nil, errors.New("Configuration did not contain a backend")
 	}
 	return blobstore.NewMetricsBlobAccess(implementation, fmt.Sprintf("%s_%s", storageType, backendType)), nil
+}
+
+type RedisConfig struct {
+	Pwd                                         string
+	Ttl, DialTimeout, ReadTimeout, WriteTimeout int
+}
+
+func setRedisConfiguration(pwd string, ttl, dialTimeout, readTimeout, writeTimeout int) *RedisConfig {
+
+	if pwd == "" {
+		pwd = ""
+	}
+
+	if ttl == 0 {
+		ttl = 0
+	}
+
+	if dialTimeout == 0 {
+		dialTimeout = 5
+	}
+
+	if readTimeout == 0 {
+		readTimeout = 3
+	}
+
+	if writeTimeout == 0 {
+		writeTimeout = readTimeout
+	}
+
+	return &RedisConfig{
+		Pwd:          pwd,
+		Ttl:          ttl,
+		DialTimeout:  dialTimeout,
+		ReadTimeout:  readTimeout,
+		WriteTimeout: writeTimeout,
+	}
+
 }

--- a/pkg/blobstore/configuration/create_blob_access.go
+++ b/pkg/blobstore/configuration/create_blob_access.go
@@ -227,7 +227,7 @@ func createBlobAccess(configuration *pb.BlobAccessConfiguration, storageType str
 			redis.NewClient(
 				&redis.Options{
 					Addr:         backend.Redis.Endpoint,
-					Password:     rac.Password,
+					Password:     rac.Pwd,
 					DB:           int(backend.Redis.Db),
 					DialTimeout:  rac.DialTimeout,
 					ReadTimeout:  rac.ReadTimeout,
@@ -291,7 +291,7 @@ type redisAdditionalConfig struct {
 	Ttl, DialTimeout, ReadTimeout, WriteTimeout time.Duration
 }
 
-func setRedisConfiguration(pwd string, ttl, dialTimeout, readTimeout, writeTimeout int) *RedisConfig {
+func setRedisConfiguration(pwd string, ttl, dialTimeout, readTimeout, writeTimeout int) *redisAdditionalConfig {
 
 	if pwd == "" {
 		pwd = ""

--- a/pkg/blobstore/redis_blob_access.go
+++ b/pkg/blobstore/redis_blob_access.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"io/ioutil"
+	"time"
 
 	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/go-redis/redis"
@@ -15,14 +16,17 @@ import (
 type redisBlobAccess struct {
 	redisClient   *redis.Client
 	blobKeyFormat util.DigestKeyFormat
+	keyDuration   time.Duration
 }
 
 // NewRedisBlobAccess creates a BlobAccess that uses Redis as its
 // backing store.
-func NewRedisBlobAccess(redisClient *redis.Client, blobKeyFormat util.DigestKeyFormat) BlobAccess {
+//keyDuration added
+func NewRedisBlobAccess(redisClient *redis.Client, blobKeyFormat util.DigestKeyFormat, keyDuration time.Duration) BlobAccess {
 	return &redisBlobAccess{
 		redisClient:   redisClient,
 		blobKeyFormat: blobKeyFormat,
+		keyDuration:   keyDuration,
 	}
 }
 
@@ -33,7 +37,7 @@ func (ba *redisBlobAccess) Get(ctx context.Context, digest *util.Digest) (int64,
 	value, err := ba.redisClient.Get(digest.GetKey(ba.blobKeyFormat)).Bytes()
 	if err != nil {
 		if err == redis.Nil {
-			return 0, nil, util.StatusWrapWithCode(err, codes.NotFound, "Failed to get blob")
+			return 0, nil, util.StatusWrapWithCode(err, codes.NotFound, "Key does not exist in db")
 		}
 		return 0, nil, util.StatusWrapWithCode(err, codes.Unavailable, "Failed to get blob")
 	}
@@ -50,7 +54,7 @@ func (ba *redisBlobAccess) Put(ctx context.Context, digest *util.Digest, sizeByt
 	if err != nil {
 		return util.StatusWrapWithCode(err, codes.Unavailable, "Failed to put blob")
 	}
-	return ba.redisClient.Set(digest.GetKey(ba.blobKeyFormat), value, 0).Err()
+	return ba.redisClient.Set(digest.GetKey(ba.blobKeyFormat), value, ba.keyDuration).Err()
 }
 
 func (ba *redisBlobAccess) Delete(ctx context.Context, digest *util.Digest) error {

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -117,6 +117,28 @@ message RedisBlobAccessConfiguration {
 
   // Numerical ID of the database.
   int32 db = 2;
+
+   // Redis Auth Password
+  // Default is "" (NO Password)
+  string password = 3;
+
+  // Key TTL duration in secs
+  // Default 0 for No TTL duration (TTL will be set -1)
+  int64 key_ttl_duration = 4;
+
+  /// Dial timeout for establishing new connections in seconds
+	// Default is 5.
+  int64 dial_timeout = 5;
+
+  // Timeout for socket reads in seconds. If reached, commands will fail
+	// with a timeout instead of blocking.
+	// Default is 3.
+  int64 read_timeout = 6;
+
+  // Timeout for socket writes in seconds. If reached, commands will fail
+	// with a timeout instead of blocking.
+	// Default is ReadTimeout.
+  int64 write_timeout = 7;
 }
 
 message RemoteBlobAccessConfiguration {

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -123,16 +123,16 @@ message RedisBlobAccessConfiguration {
   string password = 3;
 
   // Key TTL duration in secs
-  // Default 0 for No TTL duration (TTL will be set -1)
+  // Default 0 for No TTL duration (TTL will be set -1 in Redis)
   int64 key_ttl_duration = 4;
 
   /// Dial timeout for establishing new connections in seconds
-	// Default is 5.
+	// Default is 5 secs.
   int64 dial_timeout = 5;
 
   // Timeout for socket reads in seconds. If reached, commands will fail
 	// with a timeout instead of blocking.
-	// Default is 3.
+	// Default is 3 secs.
   int64 read_timeout = 6;
 
   // Timeout for socket writes in seconds. If reached, commands will fail


### PR DESCRIPTION
Added additional Redis configs to be used for using Redis as backend:

- TTL duration for keys in seconds
- Password
- DialTimeout for Redis Client
- ReadTimeout for Redis Client
- WriteTimeout for Redis Client.

**Config changes**: We need to include a similar kind of config as below in storage.yaml (using K8). See the changed blobstore.proto for the configs. (Overridden with Default values, if above configs not present.)

**Note:** The strategy of TTL Duration on keys is optional and not needed for using a` maxmemory-policy` or any other key eviction policies in use.
