### PR TITLE
Added grpc go library

### DIFF
--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -57,6 +57,13 @@ def bb_storage_go_dependencies():
         urls = ["https://github.com/go-redis/redis/archive/v6.15.1.tar.gz"],
     )
 
+    # v1.26.0
+    go_repository(
+        name = "org_golang_google_grpc",
+        commit = "f5b0812e6fe574d90da76b205e9eb51f6ddb1919",
+        importpath = "google.golang.org/grpc",
+    )
+
     go_repository(
         name = "com_github_grpc_ecosystem_go_grpc_prometheus",
         importpath = "github.com/grpc-ecosystem/go-grpc-prometheus",


### PR DESCRIPTION
I do not have the grpc Go library in my app's WORKSPACE, and encountered a compilation failure (lib not found).