### PR TITLE
Extend opencensus support

### DIFF
--- a/pkg/ac/BUILD.bazel
+++ b/pkg/ac/BUILD.bazel
@@ -12,5 +12,6 @@ go_library(
         "@com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )

--- a/pkg/ac/action_cache_server.go
+++ b/pkg/ac/action_cache_server.go
@@ -10,6 +10,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"go.opencensus.io/trace"
 )
 
 type actionCacheServer struct {
@@ -29,6 +31,8 @@ func NewActionCacheServer(blobAccess blobstore.BlobAccess, allowUpdatesForInstan
 }
 
 func (s *actionCacheServer) GetActionResult(ctx context.Context, in *remoteexecution.GetActionResultRequest) (*remoteexecution.ActionResult, error) {
+	ctx, span := trace.StartSpan(ctx, "actionResult.Get")
+	defer span.End()
 	digest, err := util.NewDigest(in.InstanceName, in.ActionDigest)
 	if err != nil {
 		return nil, err
@@ -37,6 +41,8 @@ func (s *actionCacheServer) GetActionResult(ctx context.Context, in *remoteexecu
 }
 
 func (s *actionCacheServer) UpdateActionResult(ctx context.Context, in *remoteexecution.UpdateActionResultRequest) (*remoteexecution.ActionResult, error) {
+	ctx, span := trace.StartSpan(ctx, "actionResult.Update")
+	defer span.End()
 	digest, err := util.NewDigest(in.InstanceName, in.ActionDigest)
 	if err != nil {
 		return nil, err

--- a/pkg/blobstore/BUILD.bazel
+++ b/pkg/blobstore/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_x_net//context/ctxhttp:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/pkg/blobstore/circular/circular_blob_access.go
+++ b/pkg/blobstore/circular/circular_blob_access.go
@@ -65,7 +65,7 @@ func NewCircularBlobAccess(offsetStore OffsetStore, dataStore DataStore, stateSt
 }
 
 func (ba *circularBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
-	ctx, span := trace.StartSpan(ctx, "circularBlobAccess.Get")
+	ctx, span := trace.StartSpan(ctx, "blobstore.CircularBlobAccess.Get")
 	defer span.End()
 
 	ba.lock.Lock()
@@ -105,7 +105,7 @@ func (ba *circularBlobAccess) Put(ctx context.Context, digest *util.Digest, b bu
 	r := b.ToReader()
 	defer r.Close()
 
-	ctx, span := trace.StartSpan(ctx, "circularBlobAccess.Put")
+	ctx, span := trace.StartSpan(ctx, "blobstore.CircularBlobAccess.Put")
 	defer span.End()
 
 	// Allocate space in the data store.
@@ -138,6 +138,9 @@ func (ba *circularBlobAccess) Put(ctx context.Context, digest *util.Digest, b bu
 }
 
 func (ba *circularBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.CircularBlobAccess.FindMissing")
+	defer span.End()
+
 	ba.lock.Lock()
 	defer ba.lock.Unlock()
 

--- a/pkg/blobstore/cloud_blob_access.go
+++ b/pkg/blobstore/cloud_blob_access.go
@@ -12,6 +12,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"go.opencensus.io/trace"
 )
 
 type cloudBlobAccess struct {
@@ -31,6 +33,9 @@ func NewCloudBlobAccess(bucket *blob.Bucket, keyPrefix string, storageType Stora
 }
 
 func (ba *cloudBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.CloudBlobAccess.Get")
+	defer span.End()
+
 	key := ba.getKey(digest)
 	result, err := ba.bucket.NewReader(ctx, key, nil)
 	if err != nil {
@@ -48,6 +53,9 @@ func (ba *cloudBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.
 }
 
 func (ba *cloudBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.CloudBlobAccess.Put")
+	defer span.End()
+
 	r := b.ToReader()
 	defer r.Close()
 
@@ -70,6 +78,9 @@ func (ba *cloudBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffe
 }
 
 func (ba *cloudBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.CloudBlobAccess.FindMissing")
+	defer span.End()
+
 	var missing []*util.Digest
 	for _, digest := range digests {
 		if exists, err := ba.bucket.Exists(ctx, ba.getKey(digest)); err != nil {

--- a/pkg/blobstore/content_addressable_storage_blob_access.go
+++ b/pkg/blobstore/content_addressable_storage_blob_access.go
@@ -14,6 +14,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"go.opencensus.io/trace"
 )
 
 type contentAddressableStorageBlobAccess struct {
@@ -55,6 +57,9 @@ func (r *byteStreamChunkReader) Close() {
 }
 
 func (ba *contentAddressableStorageBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ContentAddressableStorageBlobAccess.Get")
+	defer span.End()
+
 	var readRequest bytestream.ReadRequest
 	if instance := digest.GetInstance(); instance == "" {
 		readRequest.ResourceName = fmt.Sprintf("blobs/%s/%d", digest.GetHashString(), digest.GetSizeBytes())
@@ -73,6 +78,9 @@ func (ba *contentAddressableStorageBlobAccess) Get(ctx context.Context, digest *
 }
 
 func (ba *contentAddressableStorageBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ContentAddressableStorageBlobAccess.Put")
+	defer span.End()
+
 	r := b.ToChunkReader(0, ba.readChunkSize)
 	defer r.Close()
 
@@ -119,6 +127,9 @@ func (ba *contentAddressableStorageBlobAccess) Put(ctx context.Context, digest *
 }
 
 func (ba *contentAddressableStorageBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ContentAddressableStorageBlobAccess.FindMissing")
+	defer span.End()
+
 	// Convert digests to line format.
 	if len(digests) == 0 {
 		return nil, nil

--- a/pkg/blobstore/local/BUILD.bazel
+++ b/pkg/blobstore/local/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/pkg/blobstore/local/local_blob_access.go
+++ b/pkg/blobstore/local/local_blob_access.go
@@ -12,6 +12,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"go.opencensus.io/trace"
 )
 
 var (
@@ -238,6 +240,9 @@ func (ba *localBlobAccess) allocateSpace(sizeBytes int64) (Block, Location) {
 }
 
 func (ba *localBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.LocalBlobAccess.Get")
+	defer span.End()
+
 	// Look up the blob in the offset store.
 	ba.lock.Lock()
 	readLocation, err := ba.digestLocationMap.Get(digest, &ba.locationValidator)
@@ -274,6 +279,9 @@ func (ba *localBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.
 }
 
 func (ba *localBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.LocalBlobAccess.Put")
+	defer span.End()
+
 	sizeBytes, err := b.GetSizeBytes()
 	if err != nil {
 		b.Discard()
@@ -311,6 +319,9 @@ type blobRefresh struct {
 }
 
 func (ba *localBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.LocalBlobAccess.FindMissing")
+	defer span.End()
+
 	// Scan the offset store to determine which blobs are present.
 	ba.lock.Lock()
 	var missing []*util.Digest

--- a/pkg/blobstore/mirrored_blob_access.go
+++ b/pkg/blobstore/mirrored_blob_access.go
@@ -11,6 +11,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"go.opencensus.io/trace"
 )
 
 var (
@@ -52,6 +54,9 @@ func NewMirroredBlobAccess(backendA BlobAccess, backendB BlobAccess) BlobAccess 
 }
 
 func (ba *mirroredBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.MirroredBlobAccess.Get")
+	defer span.End()
+
 	// Alternate requests between storage backends.
 	var firstBackend, secondBackend BlobAccess
 	var firstBackendName, secondBackendName string
@@ -76,6 +81,9 @@ func (ba *mirroredBlobAccess) Get(ctx context.Context, digest *util.Digest) buff
 }
 
 func (ba *mirroredBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.MirroredBlobAccess.Get")
+	defer span.End()
+
 	// Store object in both storage backends.
 	b1, b2 := b.CloneStream()
 	errAChan := make(chan error, 1)

--- a/pkg/blobstore/read_caching_blob_access.go
+++ b/pkg/blobstore/read_caching_blob_access.go
@@ -8,6 +8,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"go.opencensus.io/trace"
 )
 
 type readCachingBlobAccess struct {
@@ -28,6 +30,9 @@ func NewReadCachingBlobAccess(slow BlobAccess, fast BlobAccess) BlobAccess {
 }
 
 func (ba *readCachingBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ReadCachingBlobAccess.Get")
+	defer span.End()
+
 	return buffer.WithErrorHandler(
 		ba.fast.Get(ctx, digest),
 		&readCachingErrorHandler{
@@ -38,10 +43,14 @@ func (ba *readCachingBlobAccess) Get(ctx context.Context, digest *util.Digest) b
 }
 
 func (ba *readCachingBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ReadCachingBlobAccess.Put")
+	defer span.End()
 	return ba.slow.Put(ctx, digest, b)
 }
 
 func (ba *readCachingBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ReadCachingBlobAccess.FindMissing")
+	defer span.End()
 	return ba.slow.FindMissing(ctx, digests)
 }
 

--- a/pkg/blobstore/redis_blob_access.go
+++ b/pkg/blobstore/redis_blob_access.go
@@ -10,6 +10,8 @@ import (
 	"github.com/go-redis/redis"
 
 	"google.golang.org/grpc/codes"
+
+	"go.opencensus.io/trace"
 )
 
 // RedisClient is an interface that contains the set of functions of the
@@ -45,6 +47,9 @@ func NewRedisBlobAccess(redisClient RedisClient,
 }
 
 func (ba *redisBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.RedisBlobAccess.Get")
+	defer span.End()
+
 	if err := util.StatusFromContext(ctx); err != nil {
 		return buffer.NewBufferFromError(err)
 	}
@@ -64,6 +69,9 @@ func (ba *redisBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.
 }
 
 func (ba *redisBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.RedisBlobAccess.Put")
+	defer span.End()
+
 	if err := util.StatusFromContext(ctx); err != nil {
 		b.Discard()
 		return err
@@ -101,6 +109,9 @@ func (ba *redisBlobAccess) waitIfReplicationEnabled() error {
 }
 
 func (ba *redisBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.RedisBlobAccess.FindMissing")
+	defer span.End()
+
 	if err := util.StatusFromContext(ctx); err != nil {
 		return nil, err
 	}

--- a/pkg/blobstore/remote_blob_access.go
+++ b/pkg/blobstore/remote_blob_access.go
@@ -12,6 +12,8 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"go.opencensus.io/trace"
 )
 
 type remoteBlobAccess struct {
@@ -36,6 +38,9 @@ func NewRemoteBlobAccess(address string, prefix string, storageType StorageType)
 }
 
 func (ba *remoteBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.RemoteBlobAccess.Get")
+	defer span.End()
+
 	url := fmt.Sprintf("%s/%s/%s", ba.address, ba.prefix, digest.GetHashString())
 	resp, err := ctxhttp.Get(ctx, http.DefaultClient, url)
 	if err != nil {
@@ -55,6 +60,9 @@ func (ba *remoteBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer
 }
 
 func (ba *remoteBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.RemoteBlobAccess.Put")
+	defer span.End()
+
 	sizeBytes, err := b.GetSizeBytes()
 	if err != nil {
 		b.Discard()
@@ -73,6 +81,9 @@ func (ba *remoteBlobAccess) Put(ctx context.Context, digest *util.Digest, b buff
 }
 
 func (ba *remoteBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.RemoteBlobAccess.FindMissing")
+	defer span.End()
+
 	var missing []*util.Digest
 	for _, digest := range digests {
 		url := fmt.Sprintf("%s/%s/%s", ba.address, ba.prefix, digest.GetHashString())

--- a/pkg/blobstore/sharding/BUILD.bazel
+++ b/pkg/blobstore/sharding/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/blobstore/buffer:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_lazybeaver_xorshift//:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/pkg/blobstore/sharding/sharding_blob_access.go
+++ b/pkg/blobstore/sharding/sharding_blob_access.go
@@ -6,6 +6,8 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/blobstore"
 	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/util"
+
+	"go.opencensus.io/trace"
 )
 
 type shardingBlobAccess struct {
@@ -45,10 +47,16 @@ func (ba *shardingBlobAccess) getBackend(digest *util.Digest) blobstore.BlobAcce
 }
 
 func (ba *shardingBlobAccess) Get(ctx context.Context, digest *util.Digest) buffer.Buffer {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ShardingBlobAccess.Get")
+	defer span.End()
+
 	return ba.getBackend(digest).Get(ctx, digest)
 }
 
 func (ba *shardingBlobAccess) Put(ctx context.Context, digest *util.Digest, b buffer.Buffer) error {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ShardingBlobAccess.Put")
+	defer span.End()
+
 	return ba.getBackend(digest).Put(ctx, digest, b)
 }
 
@@ -63,6 +71,9 @@ func callFindMissing(ctx context.Context, blobAccess blobstore.BlobAccess, diges
 }
 
 func (ba *shardingBlobAccess) FindMissing(ctx context.Context, digests []*util.Digest) ([]*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "blobstore.ShardingBlobAccess.FindMissing")
+	defer span.End()
+
 	// Determine which backends to contact.
 	digestsPerBackend := map[blobstore.BlobAccess][]*util.Digest{}
 	for _, digest := range digests {

--- a/pkg/builder/BUILD.bazel
+++ b/pkg/builder/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/pkg/cas/BUILD.bazel
+++ b/pkg/cas/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@go_googleapis//google/bytestream:bytestream_go_proto",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
     ],
 )
 

--- a/pkg/cas/blob_access_content_addressable_storage.go
+++ b/pkg/cas/blob_access_content_addressable_storage.go
@@ -13,6 +13,8 @@ import (
 	cas_proto "github.com/buildbarn/bb-storage/pkg/proto/cas"
 	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/golang/protobuf/proto"
+
+	"go.opencensus.io/trace"
 )
 
 type blobAccessContentAddressableStorage struct {
@@ -39,6 +41,9 @@ func (cas *blobAccessContentAddressableStorage) getMessage(ctx context.Context, 
 }
 
 func (cas *blobAccessContentAddressableStorage) GetAction(ctx context.Context, digest *util.Digest) (*remoteexecution.Action, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.GetAction")
+	defer span.End()
+
 	var action remoteexecution.Action
 	if err := cas.getMessage(ctx, digest, &action); err != nil {
 		return nil, err
@@ -47,6 +52,9 @@ func (cas *blobAccessContentAddressableStorage) GetAction(ctx context.Context, d
 }
 
 func (cas *blobAccessContentAddressableStorage) GetUncachedActionResult(ctx context.Context, digest *util.Digest) (*cas_proto.UncachedActionResult, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.GetUncachedActionResult")
+	defer span.End()
+
 	var uncachedActionResult cas_proto.UncachedActionResult
 	if err := cas.getMessage(ctx, digest, &uncachedActionResult); err != nil {
 		return nil, err
@@ -55,6 +63,9 @@ func (cas *blobAccessContentAddressableStorage) GetUncachedActionResult(ctx cont
 }
 
 func (cas *blobAccessContentAddressableStorage) GetCommand(ctx context.Context, digest *util.Digest) (*remoteexecution.Command, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.GetCommand")
+	defer span.End()
+
 	var command remoteexecution.Command
 	if err := cas.getMessage(ctx, digest, &command); err != nil {
 		return nil, err
@@ -63,6 +74,9 @@ func (cas *blobAccessContentAddressableStorage) GetCommand(ctx context.Context, 
 }
 
 func (cas *blobAccessContentAddressableStorage) GetDirectory(ctx context.Context, digest *util.Digest) (*remoteexecution.Directory, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.GetDirectory")
+	defer span.End()
+
 	var directory remoteexecution.Directory
 	if err := cas.getMessage(ctx, digest, &directory); err != nil {
 		return nil, err
@@ -71,6 +85,9 @@ func (cas *blobAccessContentAddressableStorage) GetDirectory(ctx context.Context
 }
 
 func (cas *blobAccessContentAddressableStorage) GetFile(ctx context.Context, digest *util.Digest, directory filesystem.Directory, name string, isExecutable bool) error {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.GetFile")
+	defer span.End()
+
 	var mode os.FileMode = 0444
 	if isExecutable {
 		mode = 0555
@@ -91,6 +108,9 @@ func (cas *blobAccessContentAddressableStorage) GetFile(ctx context.Context, dig
 }
 
 func (cas *blobAccessContentAddressableStorage) GetTree(ctx context.Context, digest *util.Digest) (*remoteexecution.Tree, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.GetTree")
+	defer span.End()
+
 	var tree remoteexecution.Tree
 	if err := cas.getMessage(ctx, digest, &tree); err != nil {
 		return nil, err
@@ -121,6 +141,9 @@ func (cas *blobAccessContentAddressableStorage) putMessage(ctx context.Context, 
 }
 
 func (cas *blobAccessContentAddressableStorage) PutFile(ctx context.Context, directory filesystem.Directory, name string, parentDigest *util.Digest) (*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.PutFile")
+	defer span.End()
+
 	file, err := directory.OpenRead(name)
 	if err != nil {
 		return nil, err
@@ -166,10 +189,16 @@ func newSectionReadCloser(r filesystem.FileReader, off int64, n int64) io.ReadCl
 }
 
 func (cas *blobAccessContentAddressableStorage) PutLog(ctx context.Context, log []byte, parentDigest *util.Digest) (*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.PutLog")
+	defer span.End()
+
 	return cas.putBlob(ctx, log, parentDigest)
 }
 
 func (cas *blobAccessContentAddressableStorage) PutTree(ctx context.Context, tree *remoteexecution.Tree, parentDigest *util.Digest) (*util.Digest, error) {
+	ctx, span := trace.StartSpan(ctx, "cas.BlobAccess.PutTree")
+	defer span.End()
+
 	return cas.putMessage(ctx, tree, parentDigest)
 }
 

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -41,7 +41,8 @@ func NewGRPCClientFromConfiguration(configuration *configuration.GRPCClientConfi
 		configuration.Address,
 		securityOption,
 		grpc.WithUnaryInterceptor(grpc_prometheus.UnaryClientInterceptor),
-		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor))
+		grpc.WithStreamInterceptor(grpc_prometheus.StreamClientInterceptor),
+		grpc.WithStatsHandler(new(ocgrpc.ClientHandler)))
 }
 
 // NewGRPCServersFromConfigurationAndServe creates a series of gRPC


### PR DESCRIPTION
In an effort to improve observability (in conjunction with https://github.com/buildbarn/bb-remote-execution/pull/32) I've annotated a number of additional spans. This obviously couples the trancing tightly to the rest of the system, but the functions only actually do anything if opentracing is added in the config.

(the image below is using both this patch and the one referenced on bb-remote-execution)

![image](https://user-images.githubusercontent.com/8715352/74438831-e7be6e80-4e62-11ea-9a43-48f39234989a.png)
