### PR TITLE
Enable more autoformatters on our codebase

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -7,26 +7,20 @@ on:
     branches:
     - master
 jobs:
-  gofmt:
-    runs-on: ubuntu-latest
-    container: docker://golang:1.13
-    steps:
-    - uses: actions/checkout@v1
-    - name: run gofmt
-      run: test -z "$(gofmt -d . | tee /dev/stderr)"
-  buildifier:
-    runs-on: ubuntu-latest
-    container: docker://golang:1.13
-    steps:
-    - uses: actions/checkout@v1
-    - name: install buildifier
-      run: go get github.com/bazelbuild/buildtools/buildifier
-    - name: run buildifier
-      run: buildifier -mode=check -r .
   build_and_test:
     runs-on: ubuntu-latest
     container: docker://l.gcr.io/google/bazel:2.1.0
     steps:
     - uses: actions/checkout@v1
-    - name: build and test
+    - name: Bazel build and test
       run: bazel test //...
+    - name: Buildifier
+      run: bazel run @com_github_bazelbuild_buildtools//:buildifier
+    - name: Gazelle
+      run: bazel run //:gazelle
+    - name: Gofmt
+      run: bazel run @go_sdk//:bin/gofmt -- -s -w .
+    - name: Clang format
+      run: find . -name '*.proto' -exec bazel run @llvm_toolchain//:bin/clang-format -- -i {} +
+    - name: Test style conformance
+      run: git diff --exit-code HEAD --

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -103,3 +103,17 @@ http_archive(
     strip_prefix = "bb-deployments-cf505b7f363ce87798a367d6741b8f550a5e077a",
     url = "https://github.com/buildbarn/bb-deployments/archive/cf505b7f363ce87798a367d6741b8f550a5e077a.tar.gz",
 )
+
+http_archive(
+    name = "com_grail_bazel_toolchain",
+    sha256 = "b3dec631fe2be45b3a7a8a4161dd07fadc68825842e8d6305ed35bc8560968ca",
+    strip_prefix = "bazel-toolchain-0.5.1",
+    urls = ["https://github.com/grailbio/bazel-toolchain/archive/0.5.1.tar.gz"],
+)
+
+load("@com_grail_bazel_toolchain//toolchain:rules.bzl", "llvm_toolchain")
+
+llvm_toolchain(
+    name = "llvm_toolchain",
+    llvm_version = "9.0.0",
+)

--- a/pkg/proto/configuration/blobstore/BUILD.bazel
+++ b/pkg/proto/configuration/blobstore/BUILD.bazel
@@ -7,7 +7,6 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/digest:digest_proto",
-        "//pkg/proto/configuration/eviction:eviction_proto",
         "//pkg/proto/configuration/grpc:grpc_proto",
         "//pkg/proto/configuration/tls:tls_proto",
         "@com_google_protobuf//:duration_proto",
@@ -23,7 +22,6 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/digest:go_default_library",
-        "//pkg/proto/configuration/eviction:go_default_library",
         "//pkg/proto/configuration/grpc:go_default_library",
         "//pkg/proto/configuration/tls:go_default_library",
         "@go_googleapis//google/rpc:status_go_proto",

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -190,7 +190,6 @@ message SingleRedisBlobAccessConfiguration {
 
   // Redis Auth Password, "" for NO Password
   string password = 3;
-
 }
 
 message RedisBlobAccessConfiguration {
@@ -234,8 +233,8 @@ message RedisBlobAccessConfiguration {
   // Default value can be overidden (e.g, '300s').
   google.protobuf.Duration read_timeout = 11;
 
-  // Timeout for socket writes. If reached, commands will fail with a timeout 
-  // instead of blocking. Defaults to ReadTimeout, 
+  // Timeout for socket writes. If reached, commands will fail with a timeout
+  // instead of blocking. Defaults to ReadTimeout,
   // can be overidden (e.g, '300s').
   google.protobuf.Duration write_timeout = 12;
 }


### PR DESCRIPTION
Instead of having separate containers that do a 'go get' to obtain these
tools, fetch all of them through the Bazel workspace. This ensures that
we always stick to a fixed version.