### PR TITLE
Support grpc reflection

### DIFF
--- a/pkg/grpc/BUILD.bazel
+++ b/pkg/grpc/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
         "@org_golang_google_grpc//peer:go_default_library",
+        "@org_golang_google_grpc//reflection:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
     ],
 )

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 
 	"go.opencensus.io/plugin/ocgrpc"
@@ -91,6 +92,9 @@ func NewGRPCServersFromConfigurationAndServe(configurations []*configuration.GRP
 		// Add Prometheus timing metrics.
 		grpc_prometheus.EnableHandlingTimeHistogram(grpc_prometheus.WithHistogramBuckets(prometheus.DefBuckets))
 		grpc_prometheus.Register(s)
+
+		// Enable grpc reflection.
+		reflection.Register(s)
 
 		if len(configuration.ListenAddresses)+len(configuration.ListenPaths) == 0 {
 			return status.Error(codes.InvalidArgument, "GRPC server configured without any listen addresses or paths")


### PR DESCRIPTION
Just a small usability improvement for those of us using [grpcurl](https://github.com/fullstorydev/grpcurl):

```
$ grpcurl -plaintext localhost:8981 list
build.bazel.remote.execution.v2.ActionCache
build.bazel.remote.execution.v2.Capabilities
build.bazel.remote.execution.v2.ContentAddressableStorage
build.bazel.remote.execution.v2.Execution
google.bytestream.ByteStream
grpc.reflection.v1alpha.ServerReflection

$ grpcurl -plaintext localhost:8981 describe build.bazel.remote.execution.v2.ActionCache
build.bazel.remote.execution.v2.ActionCache is a service:
service ActionCache {
  rpc GetActionResult ( .build.bazel.remote.execution.v2.GetActionResultRequest ) returns ( .build.bazel.remote.execution.v2.ActionResult ) {
    option (.google.api.http) = { get:"/v2/{instance_name=**}/actionResults/{action_digest.hash}/{action_digest.size_bytes}" };
  }
  rpc UpdateActionResult ( .build.bazel.remote.execution.v2.UpdateActionResultRequest ) returns ( .build.bazel.remote.execution.v2.ActionResult ) {
    option (.google.api.http) = { put:"/v2/{instance_name=**}/actionResults/{action_digest.hash}/{action_digest.size_bytes}" body:"action_result" };
  }
}
```