### PR TITLE
Update rules_docker to 0.14.1.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -21,9 +21,9 @@ http_archive(
 
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "14ac30773fdb393ddec90e158c9ec7ebb3f8a4fd533ec2abbfd8789ad81a284b",
-    strip_prefix = "rules_docker-0.12.1",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.12.1/rules_docker-v0.12.1.tar.gz"],
+    sha256 = "dc97fccceacd4c6be14e800b2a00693d5e8d07f69ee187babfd04a80a9f8e250",
+    strip_prefix = "rules_docker-0.14.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.1/rules_docker-v0.14.1.tar.gz"],
 )
 
 http_archive(


### PR DESCRIPTION
This is the latest release at the time of writing, and contains a change
that allows the container puller to work with the http(s)_proxy environment
variable (commit bazelbuild/rules_docker@66e5e1a894e, "Add http(s)_proxy env
var support to puller (#1359)").