### PR TITLE
CloudBlobAccess: Use Buffer API for Put

### DIFF
--- a/pkg/blobstore/cloud_blob_access.go
+++ b/pkg/blobstore/cloud_blob_access.go
@@ -51,6 +51,7 @@ func (ba *cloudBlobAccess) Put(ctx context.Context, digest digest.Digest, b buff
 	w, err := ba.bucket.NewWriter(ctx, ba.getKey(digest), nil)
 	if err != nil {
 		cancel()
+		b.Discard()
 		return err
 	}
 	// In case of an error (e.g. network failure), we cancel before closing to

--- a/pkg/blobstore/cloud_blob_access.go
+++ b/pkg/blobstore/cloud_blob_access.go
@@ -2,7 +2,6 @@ package blobstore
 
 import (
 	"context"
-	"io"
 
 	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
@@ -48,9 +47,6 @@ func (ba *cloudBlobAccess) Get(ctx context.Context, digest digest.Digest) buffer
 }
 
 func (ba *cloudBlobAccess) Put(ctx context.Context, digest digest.Digest, b buffer.Buffer) error {
-	r := b.ToReader()
-	defer r.Close()
-
 	ctx, cancel := context.WithCancel(ctx)
 	w, err := ba.bucket.NewWriter(ctx, ba.getKey(digest), nil)
 	if err != nil {
@@ -59,7 +55,7 @@ func (ba *cloudBlobAccess) Put(ctx context.Context, digest digest.Digest, b buff
 	}
 	// In case of an error (e.g. network failure), we cancel before closing to
 	// request the write to be aborted.
-	if _, err = io.Copy(w, r); err != nil {
+	if err = b.IntoWriter(w); err != nil {
 		cancel()
 		w.Close()
 		return err


### PR DESCRIPTION
Fixes a bug where CloudBlobAccess would cause OOM when pushing large artifacts, thanks to a `buffer.ToReader` call pulling the entire blob into memory.

Uses a ChunkReader instead, and reads/writes in chunks. I wanted to avoid setting a flag to check if EOF was reached, but I couldn't find a way to (probably due to this being my first go patch).

Closes #50 