### PR TITLE
Add support for grpc health check protocol

### DIFF
--- a/pkg/grpc/BUILD.bazel
+++ b/pkg/grpc/BUILD.bazel
@@ -23,6 +23,8 @@ go_library(
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//credentials:go_default_library",
+        "@org_golang_google_grpc//health:go_default_library",
+        "@org_golang_google_grpc//health/grpc_health_v1:go_default_library",
         "@org_golang_google_grpc//keepalive:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",
         "@org_golang_google_grpc//peer:go_default_library",

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -157,7 +157,6 @@ func NewGRPCServersFromConfigurationAndServe(configurations []*configuration.Ser
 		grpc_health_v1.RegisterHealthServer(s, h)
 		// TODO: construct an API for the caller to indicate when it is healthy and set this. Until then, we'll just track this function's extry and exit.
 		h.SetServingStatus(configuration.HealthCheckService, grpc_health_v1.HealthCheckResponse_SERVING)
-		defer h.SetServingStatus(configuration.HealthCheckService, grpc_health_v1.HealthCheckResponse_NOT_SERVING)
 
 		if len(configuration.ListenAddresses)+len(configuration.ListenPaths) == 0 {
 			return status.Error(codes.InvalidArgument, "GRPC server configured without any listen addresses or paths")

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -71,6 +71,11 @@ message ServerConfiguration {
   // Policy for allowing clients to send messages for point-to-point
   // healthchecking. The default policy is used when left unset.
   ServerKeepaliveEnforcementPolicy keepalive_enforcement_policy = 6;
+
+  // Service name for health check requests. The gRPC server will
+  // report itself healthy for this service via the grpc.health.v1
+  // protocol.
+  string health_check_service = 7;
 }
 
 message ServerKeepaliveEnforcementPolicy {


### PR DESCRIPTION
This is used with a probe like
https://github.com/grpc-ecosystem/grpc-health-probe or
https://www.envoyproxy.io/docs/envoy/latest/api-v2/api/v2/core/health_check.proto#envoy-api-msg-core-healthcheck-grpchealthcheck
to determine whether a service is both healthy and the correct
service. It is typically deployed as a load balancer health check, to
handle the scenario where:

  1. Our service is running on 1.2.3.4:8981
  2. Our service is rescheduled to run on 2.3.4.5:8981
  3. A different grpc server is started on 1.2.3.4:8981

Named service health checks allow the load balancer to notice that it
has the wrong backend, and not send it any rpcs.

In a future iteration, we should also redesign the API in this package
so that the various services can annnounce when they are ready to
serve traffic, for zero-downtime rollouts behind a load balancer. For
now, just serving a named health check at all is a step forwards.