### PR TITLE
Adds Mknod() to filesystem.Directory

### DIFF
--- a/internal/mock/BUILD.bazel
+++ b/internal/mock/BUILD.bazel
@@ -169,5 +169,6 @@ go_library(
         "@go_googleapis//google/longrunning:longrunning_go_proto",
         "@org_golang_google_grpc//:go_default_library",
         "@org_golang_google_grpc//metadata:go_default_library",
+        "@org_golang_x_sys//unix:go_default_library",
     ],
 )

--- a/pkg/filesystem/directory.go
+++ b/pkg/filesystem/directory.go
@@ -79,6 +79,8 @@ type Directory interface {
 	Lstat(name string) (FileInfo, error)
 	// Mkdir is the equivalent of os.Mkdir().
 	Mkdir(name string, perm os.FileMode) error
+	// Mknod is the equivalent of unix.Mknod().
+	Mknod(name string, perm os.FileMode, dev int) error
 	// ReadDir is the equivalent of ioutil.ReadDir().
 	ReadDir() ([]FileInfo, error)
 	// Readlink is the equivalent of os.Readlink().

--- a/pkg/filesystem/local_directory_darwin.go
+++ b/pkg/filesystem/local_directory_darwin.go
@@ -2,5 +2,16 @@
 
 package filesystem
 
+import (
+	"os"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
 // deviceNumber is the equivalent of POSIX dev_t.
 type deviceNumber = int32
+
+func (d *localDirectory) Mknod(name string, perm os.FileMode, dev int) error {
+	return status.Error(codes.Unimplemented, "Creation of device nodes is not supported on darwin")
+}

--- a/pkg/filesystem/local_directory_linux.go
+++ b/pkg/filesystem/local_directory_linux.go
@@ -2,5 +2,31 @@
 
 package filesystem
 
+import (
+	"os"
+	"runtime"
+
+	"golang.org/x/sys/unix"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
 // deviceNumber is the equivalent of POSIX dev_t.
 type deviceNumber = uint64
+
+func (d *localDirectory) Mknod(name string, perm os.FileMode, dev int) error {
+	if err := validateFilename(name); err != nil {
+		return err
+	}
+	defer runtime.KeepAlive(d)
+
+	var unixPerm uint32
+	switch perm & os.ModeType {
+	case os.ModeDevice | os.ModeCharDevice:
+		unixPerm = uint32(unix.S_IFCHR | (perm & os.ModePerm))
+	default:
+		return status.Error(codes.InvalidArgument, "The provided file mode is not for a character device")
+	}
+
+	return unix.Mknodat(d.fd, name, unixPerm, dev)
+}


### PR DESCRIPTION
Allows Mknod to be called on linux, on darwin this will give a fixed error as this operation will not work.

This is needed for a patch to bb-remote-execution to allow installation of device nodes in the input root of the action being run.