### PR TITLE
Add Utimes to directory interface

### DIFF
--- a/pkg/cas/blob_access_content_addressable_storage.go
+++ b/pkg/cas/blob_access_content_addressable_storage.go
@@ -87,6 +87,11 @@ func (cas *blobAccessContentAddressableStorage) GetFile(ctx context.Context, dig
 		directory.Remove(name)
 		return err
 	}
+	time := filesystem.DeterministicFileModificationTimestamp
+	if err := directory.Chtimes(name, time, time); err != nil {
+		directory.Remove(name)
+		return err
+	}
 	return nil
 }
 

--- a/pkg/filesystem/BUILD.bazel
+++ b/pkg/filesystem/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     importpath = "github.com/buildbarn/bb-storage/pkg/filesystem",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",
         "@org_golang_google_grpc//status:go_default_library",
         "@org_golang_x_sys//unix:go_default_library",

--- a/pkg/filesystem/local_directory_test.go
+++ b/pkg/filesystem/local_directory_test.go
@@ -386,4 +386,14 @@ func TestLocalDirectorySymlinkSuccess(t *testing.T) {
 	require.NoError(t, d.Close())
 }
 
+func TestLocalDirectoryChtimes(t *testing.T) {
+	d := openTmpDir(t)
+	time := filesystem.DeterministicFileModificationTimestamp
+	f, err := d.OpenAppend("file", filesystem.CreateExcl(0444))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.NoError(t, d.Chtimes("file", time, time))
+	require.NoError(t, d.Close())
+}
+
 // TODO(edsch): Add testing coverage for RemoveAll().


### PR DESCRIPTION
Add UtimesNano to directory interface to allow setting the mtime of files in the directory.