### PR TITLE
Add a FileBasedLocationRecordArray 

### DIFF
--- a/pkg/blobstore/local/BUILD.bazel
+++ b/pkg/blobstore/local/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "block_allocator.go",
         "digest_location_map.go",
+        "file_backed_location_record_array.go",
         "hashing_digest_location_map.go",
         "in_memory_block_allocator.go",
         "in_memory_location_record_array.go",

--- a/pkg/blobstore/local/file_backed_location_record_array.go
+++ b/pkg/blobstore/local/file_backed_location_record_array.go
@@ -1,0 +1,63 @@
+package local
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+
+	"github.com/buildbarn/bb-storage/pkg/blockdevice"
+)
+
+// FileBackedLocationRecordSize is the size of a single LocationRecord in bytes.
+const (
+	FileBackedLocationRecordSize = sha256.Size + 4 + 8 + 8 + 8
+)
+
+type fileBackedLocationRecordArray struct {
+	recordFile blockdevice.ReadWriterAt
+}
+
+// NewFileBackedLocationRecordArray creates a persistent LocationRecordArray.
+// Works by using a file as an array-like structure, writing serialised
+// LocationRecords next to each other and calculating where to Read/Write using
+// the length of a serialised record multiplied by the index.
+func NewFileBackedLocationRecordArray(recordFile blockdevice.ReadWriterAt) LocationRecordArray {
+	return &fileBackedLocationRecordArray{
+		recordFile: recordFile,
+	}
+}
+
+func (lra *fileBackedLocationRecordArray) Get(index int) (LocationRecord, error) {
+	var record [FileBackedLocationRecordSize]byte
+	if _, err := lra.recordFile.ReadAt(record[:], int64(index)*FileBackedLocationRecordSize); err != nil {
+		return LocationRecord{}, err
+	}
+
+	// Deserialize the read record into a LocationRecord
+	l := LocationRecord{
+		Key: LocationRecordKey{
+			Attempt: binary.LittleEndian.Uint32(record[32:]),
+		},
+		Location: Location{
+			BlockID:     int(binary.LittleEndian.Uint64(record[36:])),
+			OffsetBytes: int64(binary.LittleEndian.Uint64(record[44:])),
+			SizeBytes:   int64(binary.LittleEndian.Uint64(record[52:])),
+		},
+	}
+	copy(l.Key.Digest[:], record[:])
+	return l, nil
+}
+
+func (lra *fileBackedLocationRecordArray) Put(index int, locationRecord LocationRecord) error {
+	// Serialise the LocationRecord ready to be written to disk
+	var record [FileBackedLocationRecordSize]byte
+	copy(record[:], locationRecord.Key.Digest[:])
+	binary.LittleEndian.PutUint32(record[32:], locationRecord.Key.Attempt)
+	binary.LittleEndian.PutUint64(record[36:], uint64(locationRecord.Location.BlockID))
+	binary.LittleEndian.PutUint64(record[44:], uint64(locationRecord.Location.OffsetBytes))
+	binary.LittleEndian.PutUint64(record[52:], uint64(locationRecord.Location.SizeBytes))
+
+	if _, err := lra.recordFile.WriteAt(record[:60], int64(index)*FileBackedLocationRecordSize); err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/blobstore/local/hashing_digest_location_map_test.go
+++ b/pkg/blobstore/local/hashing_digest_location_map_test.go
@@ -46,7 +46,7 @@ func TestHashingDigestLocationMapPut(t *testing.T) {
 
 	t.Run("SimpleInsertion", func(t *testing.T) {
 		// An unused slot should be overwritten immediately.
-		array.EXPECT().Get(5).Return(local.LocationRecord{})
+		array.EXPECT().Get(5).Return(local.LocationRecord{}, nil)
 		array.EXPECT().Put(5, local.LocationRecord{
 			Key:      local.LocationRecordKey{Digest: digest1},
 			Location: newLocation,
@@ -71,7 +71,7 @@ func TestHashingDigestLocationMapPut(t *testing.T) {
 		array.EXPECT().Get(5).Return(local.LocationRecord{
 			Key:      local.LocationRecordKey{Digest: digest1},
 			Location: oldLocation,
-		})
+		}, nil)
 		array.EXPECT().Put(5, local.LocationRecord{
 			Key:      local.LocationRecordKey{Digest: digest1},
 			Location: newLocation,
@@ -85,7 +85,7 @@ func TestHashingDigestLocationMapPut(t *testing.T) {
 		array.EXPECT().Get(5).Return(local.LocationRecord{
 			Key:      local.LocationRecordKey{Digest: digest1},
 			Location: newLocation,
-		})
+		}, nil)
 		require.NoError(t, dlm.Put(digest1, &validator, oldLocation))
 	})
 
@@ -96,8 +96,8 @@ func TestHashingDigestLocationMapPut(t *testing.T) {
 		array.EXPECT().Get(5).Return(local.LocationRecord{
 			Key:      local.LocationRecordKey{Digest: digest2},
 			Location: newLocation,
-		})
-		array.EXPECT().Get(2).Return(local.LocationRecord{})
+		}, nil)
+		array.EXPECT().Get(2).Return(local.LocationRecord{}, nil)
 		locationRecord := local.LocationRecord{
 			Key:      local.LocationRecordKey{Digest: digest1},
 			Location: oldLocation,
@@ -114,12 +114,12 @@ func TestHashingDigestLocationMapPut(t *testing.T) {
 			Key:      local.LocationRecordKey{Digest: digest2},
 			Location: oldLocation,
 		}
-		array.EXPECT().Get(5).Return(locationRecord)
+		array.EXPECT().Get(5).Return(locationRecord, nil)
 		array.EXPECT().Put(5, local.LocationRecord{
 			Key:      local.LocationRecordKey{Digest: digest1},
 			Location: newLocation,
 		})
-		array.EXPECT().Get(6).Return(local.LocationRecord{})
+		array.EXPECT().Get(6).Return(local.LocationRecord{}, nil)
 		locationRecord.Key.Attempt++
 		array.EXPECT().Put(6, locationRecord)
 		require.NoError(t, dlm.Put(digest1, &validator, newLocation))

--- a/pkg/blobstore/local/in_memory_location_record_array.go
+++ b/pkg/blobstore/local/in_memory_location_record_array.go
@@ -15,10 +15,11 @@ func NewInMemoryLocationRecordArray(size int) LocationRecordArray {
 	}
 }
 
-func (lra *inMemoryLocationRecordArray) Get(index int) LocationRecord {
-	return lra.records[index]
+func (lra *inMemoryLocationRecordArray) Get(index int) (LocationRecord, error) {
+	return lra.records[index], nil
 }
 
-func (lra *inMemoryLocationRecordArray) Put(index int, locationRecord LocationRecord) {
+func (lra *inMemoryLocationRecordArray) Put(index int, locationRecord LocationRecord) error {
 	lra.records[index] = locationRecord
+	return nil
 }

--- a/pkg/blobstore/local/in_memory_location_record_array_test.go
+++ b/pkg/blobstore/local/in_memory_location_record_array_test.go
@@ -11,7 +11,9 @@ func TestInMemoryLocationRecordArray(t *testing.T) {
 	array := local.NewInMemoryLocationRecordArray(1024)
 
 	// Entries should be default initialized.
-	require.Equal(t, local.LocationRecord{}, array.Get(123))
+	record, err := array.Get(123)
+	require.NoError(t, err)
+	require.Equal(t, local.LocationRecord{}, record)
 
 	// Entries should be writable.
 	record1 := local.LocationRecord{
@@ -24,8 +26,11 @@ func TestInMemoryLocationRecordArray(t *testing.T) {
 			SizeBytes:   789,
 		},
 	}
-	array.Put(123, record1)
-	require.Equal(t, record1, array.Get(123))
+	err = array.Put(123, record1)
+	require.NoError(t, err)
+	record, err = array.Get(123)
+	require.NoError(t, err)
+	require.Equal(t, record1, record)
 
 	// Entries should be overwritable.
 	record2 := local.LocationRecord{
@@ -38,6 +43,10 @@ func TestInMemoryLocationRecordArray(t *testing.T) {
 			SizeBytes:   58974582,
 		},
 	}
-	array.Put(123, record2)
-	require.Equal(t, record2, array.Get(123))
+	err = array.Put(123, record2)
+	require.NoError(t, err)
+
+	record, err = array.Get(123)
+	require.NoError(t, err)
+	require.Equal(t, record2, record)
 }

--- a/pkg/blobstore/local/location_record_array.go
+++ b/pkg/blobstore/local/location_record_array.go
@@ -12,6 +12,6 @@ type LocationRecord struct {
 // data in a slice in memory, an implementation could store this
 // information on disk for a persistent data store.
 type LocationRecordArray interface {
-	Get(index int) LocationRecord
-	Put(index int, locationRecord LocationRecord)
+	Get(index int) (LocationRecord, error)
+	Put(index int, locationRecord LocationRecord) error
 }

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -474,6 +474,30 @@ message LocalBlobAccessConfiguration {
     // intended to grow capacity beyond the size of memory.
     BlockDevice block_device = 10;
   }
+
+  message InMemoryDigestLocationMap {}
+
+  message FileBackedDigestLocationMap {
+    // Path to file used for the Digest Location Map
+    string path = 1;
+
+    // Initialisation for the hash used to uniquely identify a location.
+    uint64 hash_initialization = 2;
+
+    // Whether the file used is a Block Device or not
+    bool is_block_device = 3;
+  }
+
+  oneof digest_location_map {
+    // Store the digest-location map in memory. This will be lost if
+    // bb-storage is restarted.
+    InMemoryDigestLocationMap in_memory_digest_location_map = 11;
+
+    // Store the digest-location map in a file on disk. This allows for
+    // persistency in the storage of records, and has no size limit on the
+    // number of records.
+    FileBackedDigestLocationMap file_backed_digest_location_map = 12;
+  }
 }
 
 message ExistenceCachingBlobAccessConfiguration {


### PR DESCRIPTION
Implements a LocationRecordArray that is stored in a file on disk, rather than in memory. This allows  some of the state for a LocalBlobAccess to persist between restarts, paving the way to a fully persistent LocalBlobAccess. It also likely allows for larger DigestLocationMaps, especially in memory-constrained systems.

This is a cleanup of the first half of #59.