### PR TITLE
Store state for BlockDevice-backed LocalBlobAccess

### DIFF
--- a/pkg/blobstore/local/local_blob_access_test.go
+++ b/pkg/blobstore/local/local_blob_access_test.go
@@ -25,7 +25,7 @@ func TestLocalBlobAccessAllocationPattern(t *testing.T) {
 		blocks = append(blocks, block)
 		blockAllocator.EXPECT().NewBlock().Return(block, nil)
 	}
-	blobAccess, err := local.NewLocalBlobAccess(digestLocationMap, blockAllocator, "cas", 1, 16, 2, 4, 4)
+	blobAccess, err := local.NewLocalBlobAccess(digestLocationMap, blockAllocator, "cas", 1, 16, 2, 4, 4, "")
 	require.NoError(t, err)
 
 	// After starting up, there should be a uniform distribution on
@@ -59,7 +59,7 @@ func TestLocalBlobAccessBlockRotationDuringRefreshInOldestBlock(t *testing.T) {
 	blockAllocator.EXPECT().NewBlock().Return(block2, nil)
 	block3 := mock.NewMockBlock(ctrl)
 	blockAllocator.EXPECT().NewBlock().Return(block3, nil)
-	blobAccess, err := local.NewLocalBlobAccess(digestLocationMap, blockAllocator, "cas", 1, 5, 1, 1, 1)
+	blobAccess, err := local.NewLocalBlobAccess(digestLocationMap, blockAllocator, "cas", 1, 5, 1, 1, 1, "")
 	require.NoError(t, err)
 
 	// Store "Hello and "World" to fill up the existing current and

--- a/pkg/blobstore/local/partitioning_block_allocator_test.go
+++ b/pkg/blobstore/local/partitioning_block_allocator_test.go
@@ -20,7 +20,8 @@ func TestPartitioningBlockAllocator(t *testing.T) {
 	defer ctrl.Finish()
 
 	f := mock.NewMockFileReadWriter(ctrl)
-	pa := local.NewPartitioningBlockAllocator(f, blobstore.CASStorageType, 1, 100, 10, false)
+	pa, err := local.NewPartitioningBlockAllocator(f, blobstore.CASStorageType, 1, 100, 10, false, "")
+	require.NoError(t, err)
 
 	// Based on the size of the allocator, it should be possible to
 	// create ten blocks.
@@ -32,7 +33,7 @@ func TestPartitioningBlockAllocator(t *testing.T) {
 	}
 
 	// Creating an eleventh block should fail.
-	_, err := pa.NewBlock()
+	_, err = pa.NewBlock()
 	require.Equal(t, err, status.Error(codes.ResourceExhausted, "No unused blocks available"))
 
 	// Blocks should initially be handed out in order of the offset.

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -447,6 +447,10 @@ message LocalBlobAccessConfiguration {
     // The disadvantage of enabling this option is that data corruption
     // on the block device will not be detected.
     bool disable_integrity_checking = 3;
+
+    // Path to a file in which to store the state of the blocks currently
+    // in use. Allows for persistent storage.
+    string state_path = 4;
   }
 
   oneof data_backend {


### PR DESCRIPTION
Allows a LocalBlobAccess configured with a BlockDevice backend to store
the current state, allowing it to be reloaded after a (clean) restart.
The state is stored in a file with an initial integer, expressing the
oldest block ID at time of write, followed by records expressing a
block's ID, whether it's old/current/new and the offset it's placed at.

For example:
  5 ← Oldest block Id
  0,O,123
  0,C,456
  0,N,789 ← Offset in device
  ↑ ↑
  | Whether the block is Old/Current/New
  |
  ID with respect to other blocks of the same type, restarts at 0 for
  each of old/current/new

I'm not really sure on how better to configure/store this, so feedback on that would be very welcome :)

The second half of #59, the first of which is at #62. 