### PR TITLE
Add support for metadata in gRPC client configuration

### DIFF
--- a/pkg/grpc/BUILD.bazel
+++ b/pkg/grpc/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "add_metadata_interceptor.go",
         "allow_authenticator.go",
         "any_authenticator.go",
         "authenticator.go",
@@ -37,6 +38,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "add_metadata_interceptor_test.go",
         "allow_authenticator_test.go",
         "any_authenticator_test.go",
         "deny_authenticator_test.go",

--- a/pkg/grpc/add_metadata_interceptor.go
+++ b/pkg/grpc/add_metadata_interceptor.go
@@ -1,0 +1,28 @@
+package grpc
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// NewAddMetadataUnaryClientInterceptor creates a gRPC request
+// interceptor for unary calls that adds a set of specified pairs into
+// the outgoing metadata headers. This may, for example, be used to perform
+// authentication.
+func NewAddMetadataUnaryClientInterceptor(pairs []string) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req interface{}, resp interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		return invoker(metadata.AppendToOutgoingContext(ctx, pairs...), method, req, resp, cc, opts...)
+	}
+}
+
+// NewAddMetadataStreamClientInterceptor creates a gRPC request
+// interceptor for streaming calls that adds a set of specified pairs into
+// the outgoing metadata headers. This may, for example, be used to perform
+// authentication.
+func NewAddMetadataStreamClientInterceptor(pairs []string) grpc.StreamClientInterceptor {
+	return func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+		return streamer(metadata.AppendToOutgoingContext(ctx, pairs...), desc, cc, method, opts...)
+	}
+}

--- a/pkg/grpc/add_metadata_interceptor_test.go
+++ b/pkg/grpc/add_metadata_interceptor_test.go
@@ -1,0 +1,75 @@
+package grpc_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/buildbarn/bb-storage/internal/mock"
+	bb_grpc "github.com/buildbarn/bb-storage/pkg/grpc"
+	"github.com/golang/mock/gomock"
+	"github.com/golang/protobuf/ptypes/empty"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+func TestAddMetadataUnaryClientInterceptor(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	interceptor := bb_grpc.NewAddMetadataUnaryClientInterceptor([]string{"header", "value"})
+	invoker := mock.NewMockUnaryInvoker(ctrl)
+	req := &empty.Empty{}
+	resp := &empty.Empty{}
+
+	t.Run("AddHeader", func(t *testing.T) {
+		// Outgoing request metadata should be extended
+		// with pair ("header", "value").
+		invoker.EXPECT().Call(gomock.Any(), "SomeMethod", req, resp, nil).DoAndReturn(
+			func(ctx context.Context, method string, req interface{}, resp interface{}, cc *grpc.ClientConn, opts ...grpc.CallOption) error {
+				md, ok := metadata.FromOutgoingContext(ctx)
+				require.True(t, ok)
+				require.Equal(
+					t,
+					metadata.New(map[string]string{
+						"header": "value",
+					}),
+					md)
+				return nil
+			})
+
+		require.NoError(t, interceptor(ctx, "SomeMethod", req, resp, nil, invoker.Call))
+	})
+
+}
+
+func TestAddMetadataStreamClientInterceptor(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+	defer ctrl.Finish()
+
+	interceptor := bb_grpc.NewAddMetadataStreamClientInterceptor([]string{"header", "value"})
+	streamDesc := grpc.StreamDesc{StreamName: "SomeMethod"}
+	streamer := mock.NewMockStreamer(ctrl)
+	clientStream := mock.NewMockClientStream(ctrl)
+
+	t.Run("AddHeader", func(t *testing.T) {
+		// Outgoing request metadata should be extended
+		// with pair ("header", "value").
+		streamer.EXPECT().Call(gomock.Any(), &streamDesc, nil, "SomeMethod").DoAndReturn(
+			func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+				md, ok := metadata.FromOutgoingContext(ctx)
+				require.True(t, ok)
+				require.Equal(
+					t,
+					metadata.New(map[string]string{
+						"header": "value",
+					}),
+					md)
+				return clientStream, nil
+			})
+
+		actualClientStream, err := interceptor(ctx, &streamDesc, nil, "SomeMethod", streamer.Call)
+		require.NoError(t, err)
+		require.Equal(t, clientStream, actualClientStream)
+	})
+}

--- a/pkg/grpc/add_metadata_interceptor_test.go
+++ b/pkg/grpc/add_metadata_interceptor_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/stretchr/testify/require"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -104,6 +104,24 @@ func NewGRPCClientFromConfiguration(config *configuration.ClientConfiguration) (
 			NewMetadataForwardingStreamClientInterceptor(headers))
 	}
 
+	// Optional: set metadata.
+	if md := configuration.Metadata; len(md) > 0 {
+		// convert []*configuration.ClientConfigurationHeaderValues to pairs
+		pairs := []string{}
+		for _, headerValues := range md {
+			header := headerValues.Header
+			for _, val := range headerValues.Values {
+				pairs = append(pairs, header, val)
+			}
+		}
+		unaryInterceptors = append(
+			unaryInterceptors,
+			NewAddMetadataUnaryClientInterceptor(pairs))
+		streamInterceptors = append(
+			streamInterceptors,
+			NewAddMetadataStreamClientInterceptor(pairs))
+	}
+
 	dialOptions = append(
 		dialOptions,
 		grpc.WithChainUnaryInterceptor(unaryInterceptors...),

--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -105,7 +105,7 @@ func NewGRPCClientFromConfiguration(config *configuration.ClientConfiguration) (
 	}
 
 	// Optional: set metadata.
-	if md := configuration.Metadata; len(md) > 0 {
+	if md := config.AddMetadata; len(md) > 0 {
 		// convert []*configuration.ClientConfigurationHeaderValues to pairs
 		pairs := []string{}
 		for _, headerValues := range md {

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -36,13 +36,14 @@ message ClientConfiguration {
   // Header names must be lower case.
   repeated string forward_metadata = 4;
 
-  // Map of gRPC metadata headers to set in client connection
-  // Header names must be lower case.
   message header_values {
     string header = 1;
     repeated string values = 2;
   }
-  repeated header_values metadata = 5;
+
+  // Map of gRPC metadata headers to set in client connection.
+  // Header names must be lower case.
+  repeated header_values add_metadata = 5;
 
   // Oauth authentication settings.
   // See https://grpc.io/docs/guides/auth/.

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -36,14 +36,14 @@ message ClientConfiguration {
   // Header names must be lower case.
   repeated string forward_metadata = 4;
 
-  message header_values {
+  message HeaderValues {
     string header = 1;
     repeated string values = 2;
   }
 
   // Map of gRPC metadata headers to set in client connection.
   // Header names must be lower case.
-  repeated header_values add_metadata = 5;
+  repeated HeaderValues add_metadata = 5;
 
   // Oauth authentication settings.
   // See https://grpc.io/docs/guides/auth/.

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -36,6 +36,14 @@ message ClientConfiguration {
   // Header names must be lower case.
   repeated string forward_metadata = 4;
 
+  // Map of gRPC metadata headers to set in client connection
+  // Header names must be lower case.
+  message header_values {
+    string header = 1;
+    repeated string values = 2;
+  }
+  repeated header_values metadata = 5;
+
   // Oauth authentication settings.
   // See https://grpc.io/docs/guides/auth/.
   ClientOAuthConfiguration oauth = 6;


### PR DESCRIPTION
This change allows to specify custom headers in grpc metadata in blobstore configuration, for example 

```
      blobstore: {
        contentAddressableStorage: {
          grpc: {
            address: "remote.cache.tld:443",
            metadata: [
              {
                header: "authorization",
                values: [ "Bearer tokenXXXXXXXXXXXX" ]
              },
...
```

This might be useful in case if builbarn is used as remote cache frontend which requires specific metadata like auth headers.