### PR TITLE
Adding option to dump empty base configuration model

### DIFF
--- a/cmd/bb_replicator/main.go
+++ b/cmd/bb_replicator/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -20,9 +21,17 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		log.Fatal("Usage: bb_replicator bb_replicator.jsonnet")
+		log.Fatal("Usage: bb_replicator --dump_configuration_struct | bb_replicator.jsonnet")
 	}
 	var configuration bb_replicator.ApplicationConfiguration
+	if os.Args[1] == "--dump_configuration_struct" {
+		if confDump, err := util.MarshalExample(&configuration); err != nil {
+			log.Fatal("Failed to generate configuration example structure: %s", err)
+		} else {
+			fmt.Println(confDump)
+			return
+		}
+	}
 	if err := util.UnmarshalConfigurationFromFile(os.Args[1], &configuration); err != nil {
 		log.Fatalf("Failed to read configuration from %s: %s", os.Args[1], err)
 	}

--- a/cmd/bb_storage/main.go
+++ b/cmd/bb_storage/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -24,9 +25,17 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		log.Fatal("Usage: bb_storage bb_storage.jsonnet")
+		log.Fatal("Usage: bb_storage --dump_configuration_struct | bb_storage.jsonnet")
 	}
 	var configuration bb_storage.ApplicationConfiguration
+	if os.Args[1] == "--dump_configuration_struct" {
+		if confDump, err := util.MarshalExample(&configuration); err != nil {
+			log.Fatal("Failed to generate configuration example structure: %s", err)
+		} else {
+			fmt.Println(confDump)
+			return
+		}
+	}
 	if err := util.UnmarshalConfigurationFromFile(os.Args[1], &configuration); err != nil {
 		log.Fatalf("Failed to read configuration from %s: %s", os.Args[1], err)
 	}

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -29,10 +29,12 @@ go_test(
     name = "go_default_test",
     srcs = [
         "buckets_test.go",
+        "jsonnet_test.go",
         "tls_test.go",
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/proto/configuration/bb_storage:go_default_library",
         "//pkg/proto/configuration/tls:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@org_golang_google_grpc//codes:go_default_library",

--- a/pkg/util/jsonnet_test.go
+++ b/pkg/util/jsonnet_test.go
@@ -1,0 +1,24 @@
+package util_test
+
+import (
+	"testing"
+
+	"github.com/buildbarn/bb-storage/pkg/proto/configuration/bb_storage"
+
+	"github.com/buildbarn/bb-storage/pkg/util"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJsonnetMarshalConfigurationExample(t *testing.T) {
+	var configuration bb_storage.ApplicationConfiguration
+
+	t.Run("Default", func(t *testing.T) {
+		_, err := util.MarshalExample(&configuration)
+		require.NoError(t, err)
+	})
+
+	t.Run("nully", func(t *testing.T) {
+		_, err := util.MarshalExample(nil)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
Allow easy creation of a empty/clear configuration file structure. 
Understand the capabilities/features of a software sometimes can be done by its configuration files OR checking the code itself. This could be extended to the other cmd entry points for the other components of buildbarn. The idea is to ease the visibility of available features/options.


```
./bb_storage --dump_configuration_struct
{
  "blobstore": {
    "contentAddressableStorage": {

    },
    "actionCache": {

    }
  },
  "httpListenAddress": "",
  "grpcServers": [
  ],
  "schedulers": {
  },
  "allowAcUpdatesForInstances": [
  ],
  "maximumMessageSizeBytes": "0",
  "global": {
    "jaeger": {
      "agentEndpoint": "",
      "collectorEndpoint": "",
      "serviceName": "",
      "alwaysSample": false
    },
    "mutexProfileFraction": 0,
    "prometheusPushgateway": {
      "url": "",
      "job": "",
      "basicAuthentication": {
        "username": "",
        "password": ""
      },
      "grouping": {
      },
      "pushInterval": "0s"
    }
  }
}

```