### PR TITLE
Support instanceNames with "/" in the names

### DIFF
--- a/pkg/blobstore/grpcservers/byte_stream_server.go
+++ b/pkg/blobstore/grpcservers/byte_stream_server.go
@@ -33,7 +33,7 @@ func parseResourceNameWrite(resourceName string) (digest.Digest, error) {
 		return digest.BadDigest, status.Errorf(codes.InvalidArgument, "Invalid resource naming scheme")
 	}
 	suffixLen := 0
-	for _, i := range []int{1, 2, 3, 4, 5} {
+	for i := 1; i <= 5; i++ {
 		// 1 is for '/'
 		suffixLen = suffixLen + 1 + len(fields[l-i])
 	}

--- a/pkg/blobstore/grpcservers/byte_stream_server.go
+++ b/pkg/blobstore/grpcservers/byte_stream_server.go
@@ -24,17 +24,14 @@ import (
 func parseResourceNameWrite(resourceName string) (digest.Digest, error) {
 	fields := strings.FieldsFunc(resourceName, func(r rune) bool { return r == '/' })
 	l := len(fields)
-	if (l != 5 && l != 6) || fields[l-5] != "uploads" || fields[l-3] != "blobs" {
+	if (l < 5) || fields[l-5] != "uploads" || fields[l-3] != "blobs" {
 		return digest.BadDigest, status.Errorf(codes.InvalidArgument, "Invalid resource naming scheme")
 	}
 	size, err := strconv.ParseInt(fields[l-1], 10, 64)
 	if err != nil {
 		return digest.BadDigest, status.Errorf(codes.InvalidArgument, "Invalid resource naming scheme")
 	}
-	instance := ""
-	if l == 6 {
-		instance = fields[0]
-	}
+	instance := strings.Join(fields[0:(l-5)], "/")
 	return digest.NewDigest(instance, fields[l-2], size)
 }
 

--- a/pkg/blobstore/grpcservers/byte_stream_server_test.go
+++ b/pkg/blobstore/grpcservers/byte_stream_server_test.go
@@ -186,7 +186,7 @@ func TestByteStreamServer(t *testing.T) {
 		).Return(buffer.NewBufferFromError(status.Error(codes.NotFound, "Blob not found")))
 
 		req, err := client.Read(ctx, &bytestream.ReadRequest{
-			ResourceName: "///fedora28//blobs/09f34d28e9c8bb445ec996388968a9e8/////7/",
+			ResourceName: "fedora28/blobs/09f34d28e9c8bb445ec996388968a9e8/7",
 		})
 		require.NoError(t, err)
 		_, err = req.Recv()
@@ -205,11 +205,11 @@ func TestByteStreamServer(t *testing.T) {
 		require.Equal(t, status.Error(codes.InvalidArgument, "Invalid resource naming scheme"), err)
 	})
 
-	t.Run("WriteSuccessDoubleNameInstance", func(t *testing.T) {
+	t.Run("WriteSuccessTrickyInstance", func(t *testing.T) {
 		// Attempt to write a blob with an instance name.
 		blobAccess.EXPECT().Put(
 			gomock.Any(),
-			digest.MustNewDigest("instance/default", "581c1053f832a1c719fb6528a588ccfd", 14),
+			digest.MustNewDigest("/instance///default//", "581c1053f832a1c719fb6528a588ccfd", 14),
 			gomock.Any(),
 		).DoAndReturn(func(ctx context.Context, digest digest.Digest, b buffer.Buffer) error {
 			data, err := b.ToByteSlice(100)
@@ -221,7 +221,7 @@ func TestByteStreamServer(t *testing.T) {
 		stream, err := client.Write(ctx)
 		require.NoError(t, err)
 		require.NoError(t, stream.Send(&bytestream.WriteRequest{
-			ResourceName: "instance/default/uploads/7de747e0-ab6b-4d83-90cb-11989f84c473/blobs/581c1053f832a1c719fb6528a588ccfd/14",
+			ResourceName: "/instance///default///uploads/7de747e0-ab6b-4d83-90cb-11989f84c473/blobs/581c1053f832a1c719fb6528a588ccfd/14",
 			Data:         []byte("Laputan"),
 		}))
 		require.NoError(t, stream.Send(&bytestream.WriteRequest{

--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -146,17 +146,14 @@ func NewDigestFromPartialDigest(instance string, partialDigest *remoteexecution.
 func NewDigestFromBytestreamPath(path string) (Digest, error) {
 	fields := strings.FieldsFunc(path, func(r rune) bool { return r == '/' })
 	l := len(fields)
-	if (l != 3 && l != 4) || fields[l-3] != "blobs" {
+	if (l < 3) || fields[l-3] != "blobs" {
 		return BadDigest, status.Error(codes.InvalidArgument, "Invalid resource naming scheme")
 	}
 	size, err := strconv.ParseInt(fields[l-1], 10, 64)
 	if err != nil {
 		return BadDigest, status.Error(codes.InvalidArgument, "Invalid resource naming scheme")
 	}
-	instance := ""
-	if l == 4 {
-		instance = fields[0]
-	}
+	instance := strings.Join(fields[0:(l-3)], "/")
 	return NewDigest(instance, fields[l-2], size)
 }
 

--- a/pkg/digest/digest.go
+++ b/pkg/digest/digest.go
@@ -156,7 +156,7 @@ func NewDigestFromBytestreamPath(path string) (Digest, error) {
 		return BadDigest, status.Error(codes.InvalidArgument, "Invalid resource naming scheme")
 	}
 	suffixLen := 0
-	for _, i := range []int{1, 2, 3} {
+	for i := 1; i <= 3; i++ {
 		// 1 is for '/'
 		suffixLen = suffixLen + 1 + len(fields[l-i])
 	}


### PR DESCRIPTION
## Why

There are REAPI implementations that use `/` as a normal character in the instance names. This change should (at least partially) fix the problems with mixing them with bb.

## Test plan

Added a unit test + alternated existing tests to exercise this codepath a little.