### PR TITLE
Return ENOTDIR instead of ELOOP when working with older Linux versions

### DIFF
--- a/pkg/filesystem/local_directory.go
+++ b/pkg/filesystem/local_directory.go
@@ -56,6 +56,9 @@ func (d *localDirectory) enter(name string) (*localDirectory, error) {
 		if runtime.GOOS == "freebsd" && err == syscall.EMLINK {
 			// FreeBSD erroneously returns EMLINK.
 			return nil, syscall.ENOTDIR
+		} else if runtime.GOOS == "linux" && err == syscall.ELOOP {
+			// Linux 3.10 returns ELOOP, while Linux 4.15 returns ENOTDIR. Prefer the latter.
+			return nil, syscall.ENOTDIR
 		}
 		return nil, err
 	}


### PR DESCRIPTION
As discussed in https://github.com/buildbarn/bb-storage/issues/71 we're encountering issues when running TestLocalDirectoryEnterSymlink on our RHEL7 system (3.10.0-1127.8.2.el7.x86_64 Linux Kernel). Specifying O_PATH as a flag for openat solves this issue. 