### PR TITLE
Add stackdriver trace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/storage v1.10.0
 	contrib.go.opencensus.io/exporter/jaeger v0.2.0
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
+	contrib.go.opencensus.io/exporter/stackdriver v0.12.9 // indirect
 	github.com/Azure/azure-storage-blob-go v0.10.0
 	github.com/aws/aws-sdk-go v1.33.12
 	github.com/bazelbuild/remote-apis v0.0.0-20200708200203-1252343900d9

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	cloud.google.com/go/storage v1.10.0
 	contrib.go.opencensus.io/exporter/jaeger v0.2.0
 	contrib.go.opencensus.io/exporter/prometheus v0.2.0
-	contrib.go.opencensus.io/exporter/stackdriver v0.12.9 // indirect
+	contrib.go.opencensus.io/exporter/stackdriver v0.12.9
 	github.com/Azure/azure-storage-blob-go v0.10.0
 	github.com/aws/aws-sdk-go v1.33.12
 	github.com/bazelbuild/remote-apis v0.0.0-20200708200203-1252343900d9

--- a/go.sum
+++ b/go.sum
@@ -47,6 +47,8 @@ contrib.go.opencensus.io/exporter/jaeger v0.2.0/go.mod h1:ukdzwIYYHgZ7QYtwVFQUji
 contrib.go.opencensus.io/exporter/prometheus v0.2.0 h1:9PUk0/8V0LGoPqVCrf8fQZJkFGBxudu8jOjQSMwoD6w=
 contrib.go.opencensus.io/exporter/prometheus v0.2.0/go.mod h1:TYmVAyE8Tn1lyPcltF5IYYfWp2KHu7lQGIZnj8iZMys=
 contrib.go.opencensus.io/exporter/stackdriver v0.12.1/go.mod h1:iwB6wGarfphGGe/e5CWqyUk/cLzKnWsOKPVW3no6OTw=
+contrib.go.opencensus.io/exporter/stackdriver v0.12.9 h1:ZRVpDigsb+nVI/yps/NLDOYzYjFFmm3OCsBhmYocxR0=
+contrib.go.opencensus.io/exporter/stackdriver v0.12.9/go.mod h1:XyyafDnFOsqoxHJgTFycKZMrRUrPThLh2iYTJF6uoO0=
 contrib.go.opencensus.io/integrations/ocsql v0.1.4/go.mod h1:8DsSdjz3F+APR+0z0WkU1aRorQCFfRxvqjUUPMbF3fE=
 contrib.go.opencensus.io/resource v0.1.1/go.mod h1:F361eGI91LCmW1I/Saf+rX0+OFcigGlFvXwEGEnkRLA=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
@@ -98,6 +100,7 @@ github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1C
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/aws/aws-sdk-go v1.15.27/go.mod h1:mFuSZ37Z9YOHbQEwBWztmVzqXrEkub65tZoCYDt7FT0=
 github.com/aws/aws-sdk-go v1.19.18/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.23.20/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.31.13/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.33.12 h1:eydMoSwfrSTD9PWKUJOiDL7+/UwDW8AjInUGVE5Llh4=
 github.com/aws/aws-sdk-go v1.33.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
@@ -108,6 +111,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/census-instrumentation/opencensus-proto v0.2.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tjxl5dIMyVM=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -333,6 +337,7 @@ github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 go.opencensus.io v0.15.0/go.mod h1:UffZAU+4sDEINUGP/B7UfBBkq4fqLu9zXAX7ke6CHW0=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
+go.opencensus.io v0.22.1/go.mod h1:Ap50jQcDJrx6rB6VgeeFPtuPIf3wMRvRfrfYDO6+BmA=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.3/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.4 h1:LYy1Hy3MJdrCdMwwzxA/dRok4ejH+RwNGbuoD9fCjto=
@@ -395,6 +400,7 @@ golang.org/x/net v0.0.0-20190619014844-b5b0513f8c1b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20190912160710-24e19bdeb0f2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191112182307-2180aed22343/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -441,6 +447,7 @@ golang.org/x/sys v0.0.0-20190606165138-5da285871e9c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190912141932-bc967efca4b8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191010194322-b09406accb47/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -530,6 +537,7 @@ google.golang.org/api v0.5.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEt
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
 google.golang.org/api v0.8.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.9.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
+google.golang.org/api v0.10.0/go.mod h1:o4eAsZoiT+ibD93RtjEohWalFOjRDx6CVaqeizhEnKg=
 google.golang.org/api v0.13.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/api v0.14.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
 google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsbkAI=
@@ -546,6 +554,7 @@ google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9Ywl
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.6.1/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
+google.golang.org/appengine v1.6.2/go.mod h1:i06prIuMbXzDqacNJfV5OdTW448YApPu5ww/cMBSeb0=
 google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
 google.golang.org/appengine v1.6.6 h1:lMO5rYAqUxkmaj76jAkRUvt5JZgFymx/+Q5Mzfivuhc=
 google.golang.org/appengine v1.6.6/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
@@ -588,6 +597,7 @@ google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiq
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -359,6 +359,7 @@ def go_dependencies():
     )
     go_repository(
         name = "com_github_census_instrumentation_opencensus_proto",
+        build_extra_args = ["-exclude=src"],
         importpath = "github.com/census-instrumentation/opencensus-proto",
         sum = "h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=",
         version = "v0.2.1",

--- a/go_dependencies.bzl
+++ b/go_dependencies.bzl
@@ -841,8 +841,8 @@ def go_dependencies():
     go_repository(
         name = "io_opencensus_go_contrib_exporter_stackdriver",
         importpath = "contrib.go.opencensus.io/exporter/stackdriver",
-        sum = "h1:Dll2uFfOVI3fa8UzsHyP6z0M6fEc9ZTAMo+Y3z282Xg=",
-        version = "v0.12.1",
+        sum = "h1:ZRVpDigsb+nVI/yps/NLDOYzYjFFmm3OCsBhmYocxR0=",
+        version = "v0.12.9",
     )
     go_repository(
         name = "io_opencensus_go_contrib_integrations_ocsql",

--- a/pkg/global/BUILD.bazel
+++ b/pkg/global/BUILD.bazel
@@ -17,5 +17,6 @@ go_library(
         "@io_opencensus_go//zpages:go_default_library",
         "@io_opencensus_go_contrib_exporter_jaeger//:go_default_library",
         "@io_opencensus_go_contrib_exporter_prometheus//:go_default_library",
+        "@io_opencensus_go_contrib_exporter_stackdriver//:go_default_library",
     ],
 )

--- a/pkg/global/BUILD.bazel
+++ b/pkg/global/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "@io_opencensus_go//plugin/ocgrpc:go_default_library",
         "@io_opencensus_go//stats/view:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
-        "@io_opencensus_go//zpages:go_default_library",
         "@io_opencensus_go_contrib_exporter_jaeger//:go_default_library",
         "@io_opencensus_go_contrib_exporter_prometheus//:go_default_library",
         "@io_opencensus_go_contrib_exporter_stackdriver//:go_default_library",

--- a/pkg/global/apply_configuration.go
+++ b/pkg/global/apply_configuration.go
@@ -13,6 +13,7 @@ import (
 
 	"contrib.go.opencensus.io/exporter/jaeger"
 	prometheus_exporter "contrib.go.opencensus.io/exporter/prometheus"
+	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
@@ -49,6 +50,20 @@ func ApplyConfiguration(configuration *pb.Configuration) error {
 		}
 		trace.RegisterExporter(je)
 		if jaegerConfiguration.AlwaysSample {
+			trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+		}
+	}
+
+	if stackdriverConfiguration := configuration.GetStackdriver(); stackdriverConfiguration != nil {
+		se, err := stackdriver.NewExporter(stackdriver.Options{
+			ProjectID: stackdriverConfiguration.ProjectId,
+			Location:  stackdriverConfiguration.Location,
+		})
+		if err != nil {
+			return util.StatusWrap(err, "Failed to create the Stackdriver exporter")
+		}
+		trace.RegisterExporter(se)
+		if stackdriverConfiguration.AlwaysSample {
 			trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 		}
 	}

--- a/pkg/global/apply_configuration.go
+++ b/pkg/global/apply_configuration.go
@@ -66,10 +66,6 @@ func ApplyConfiguration(configuration *pb.Configuration) error {
 			view.RegisterExporter(pe)
 		}
 
-		if tracingConfiguration.EnableZpages {
-			zpages.Handle(nil, "/debug")
-		}
-
 		if tracingConfiguration.AlwaysSample {
 			trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
 		}

--- a/pkg/global/apply_configuration.go
+++ b/pkg/global/apply_configuration.go
@@ -17,7 +17,6 @@ import (
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/trace"
-	"go.opencensus.io/zpages"
 )
 
 // ApplyConfiguration applies configuration options to the running
@@ -55,7 +54,7 @@ func ApplyConfiguration(configuration *pb.Configuration) error {
 			trace.RegisterExporter(se)
 		}
 
-		if tracingConfiguration.ExportPrometheus {
+		if tracingConfiguration.EnablePrometheus {
 			pe, err := prometheus_exporter.NewExporter(prometheus_exporter.Options{
 				Registry:  prometheus.DefaultRegisterer.(*prometheus.Registry),
 				Namespace: "bb_storage",

--- a/pkg/proto/configuration/global/global.proto
+++ b/pkg/proto/configuration/global/global.proto
@@ -18,8 +18,8 @@ message JaegerConfiguration {
 }
 
 message StackdriverConfiguration {
-  // GCP project to send trace data to
-  // Can be left blank if in GCP, automatically determined from metadata server
+  // GCP project to which trace data is sent.
+  // Can be left blank if in GCP, automatically determined from metadata server.
   string project_id = 1;
 
   // Location is the identifier of the GCP or AWS cloud region/zone in which
@@ -60,11 +60,18 @@ message TracingConfiguration {
   // Stackdriver Trace configuration for tracing.
   StackdriverConfiguration stackdriver = 2;
 
+  // Export stats on traces to Prometheus.
+  bool enable_prometheus = 3;
+
+  // Enable zpage live data web handler on /zpages.
+  bool enable_zpages = 4
+
   // Whether or not all traces should be sampled.
-  bool always_sample = 3;
+  bool always_sample = 5;
 }
 
 message Configuration {
+  // Configuration for sending tracing data to various services.
   TracingConfiguration tracing = 1;
 
   // Sets the runtime.SetMutexProfileFraction(), so that the HTTP debug

--- a/pkg/proto/configuration/global/global.proto
+++ b/pkg/proto/configuration/global/global.proto
@@ -20,6 +20,19 @@ message JaegerConfiguration {
   bool always_sample = 4;
 }
 
+message StackdriverConfiguration {
+  // GCP project to send trace data to
+  // Can be left blank if in GCP, automatically determined from metadata server
+  string project_id = 1;
+
+  // Location is the identifier of the GCP or AWS cloud region/zone in which
+  // the data for a resource is stored. (defaults to info from metadata server)
+  string location = 2;
+
+  // Whether or not all traces should be sampled.
+  bool always_sample = 3;
+}
+
 message BasicAuthenticationConfiguration {
   // Username to store in the "Authorization: Basic" header.
   string username = 1;
@@ -49,6 +62,9 @@ message PrometheusPushgatewayConfiguration {
 message Configuration {
   // Jaeger configuration for tracing.
   JaegerConfiguration jaeger = 1;
+
+  // Stackdriver Trace configuration for tracing.
+  StackdriverConfiguration stackdriver = 4;
 
   // Sets the runtime.SetMutexProfileFraction(), so that the HTTP debug
   // endpoints used by pprof expose mutex profiling information.

--- a/pkg/proto/configuration/global/global.proto
+++ b/pkg/proto/configuration/global/global.proto
@@ -63,11 +63,8 @@ message TracingConfiguration {
   // Export stats on traces to Prometheus.
   bool enable_prometheus = 3;
 
-  // Enable zpage live data web handler on /zpages.
-  bool enable_zpages = 4
-
   // Whether or not all traces should be sampled.
-  bool always_sample = 5;
+  bool always_sample = 4;
 }
 
 message Configuration {

--- a/pkg/proto/configuration/global/global.proto
+++ b/pkg/proto/configuration/global/global.proto
@@ -15,9 +15,6 @@ message JaegerConfiguration {
 
   // OpenTracing service name.
   string service_name = 3;
-
-  // Whether or not all traces should be sampled.
-  bool always_sample = 4;
 }
 
 message StackdriverConfiguration {
@@ -28,9 +25,6 @@ message StackdriverConfiguration {
   // Location is the identifier of the GCP or AWS cloud region/zone in which
   // the data for a resource is stored. (defaults to info from metadata server)
   string location = 2;
-
-  // Whether or not all traces should be sampled.
-  bool always_sample = 3;
 }
 
 message BasicAuthenticationConfiguration {
@@ -59,12 +53,19 @@ message PrometheusPushgatewayConfiguration {
   google.protobuf.Duration push_interval = 5;
 }
 
-message Configuration {
+message TracingConfiguration {
   // Jaeger configuration for tracing.
   JaegerConfiguration jaeger = 1;
 
   // Stackdriver Trace configuration for tracing.
-  StackdriverConfiguration stackdriver = 4;
+  StackdriverConfiguration stackdriver = 2;
+
+  // Whether or not all traces should be sampled.
+  bool always_sample = 3;
+}
+
+message Configuration {
+  TracingConfiguration tracing = 1;
 
   // Sets the runtime.SetMutexProfileFraction(), so that the HTTP debug
   // endpoints used by pprof expose mutex profiling information.


### PR DESCRIPTION
Basic implementation of stackdriver tracing.
Should we extract common fields (like always sample) into a separate structure?
Should we shove this kind of thing under a tracing or debugging field with the jaeger stuff?
I punted on those for now cause it'd be a breaking config change, but more then happy to rework them