### PR TITLE
Expose S3 Multipart Upload part size.

### DIFF
--- a/pkg/blobstore/configuration/BUILD.bazel
+++ b/pkg/blobstore/configuration/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/proto/configuration/blobstore:go_default_library",
         "//pkg/util:go_default_library",
         "@com_github_aws_aws_sdk_go//service/s3:go_default_library",
+        "@com_github_aws_aws_sdk_go//service/s3/s3manager:go_default_library",
         "@com_github_azure_azure_storage_blob_go//azblob:go_default_library",
         "@com_github_go_redis_redis//:go_default_library",
         "@com_github_golang_protobuf//ptypes:go_default_library_gen",

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -293,6 +293,10 @@ message S3BlobAccessConfiguration {
 
   // AWS access options and credentials.
   buildbarn.configuration.cloud.aws.SessionConfiguration aws_session = 7;
+
+  // Multipart Upload part size. Objects smaller than the part size are uploaded
+  // as a single blob. Default and minimum is 5MB.
+  int64 part_size = 8;
 }
 
 message ShardingBlobAccessConfiguration {


### PR DESCRIPTION
Adds a setting for the Multipart Upload part size. The default SDK part
size is 5MB, which may be sub-optimal for transferring large objects.