### PR TITLE
Teach RedisBlobAccess to update TTL during Get and FindMissing calls

### DIFF
--- a/pkg/blobstore/configuration/new_blob_access.go
+++ b/pkg/blobstore/configuration/new_blob_access.go
@@ -262,6 +262,7 @@ func newNestedBlobAccessBare(configuration *pb.BlobAccessConfiguration, creator 
 				readBufferFactory,
 				digestKeyFormat,
 				keyTTL,
+				backend.Redis.RefreshTtlOnUse,
 				backend.Redis.ReplicationCount,
 				replicationTimeout),
 			DigestKeyFormat: digestKeyFormat,

--- a/pkg/blobstore/redis_blob_access_test.go
+++ b/pkg/blobstore/redis_blob_access_test.go
@@ -19,7 +19,7 @@ func TestRedisBlobAccessContextCanceled(t *testing.T) {
 	ctrl, ctx := gomock.WithContext(context.Background(), t)
 
 	redisClient := mock.NewMockRedisClient(ctrl)
-	blobAccess := blobstore.NewRedisBlobAccess(redisClient, blobstore.CASReadBufferFactory, digest.KeyWithoutInstance, 0, 0, 0)
+	blobAccess := blobstore.NewRedisBlobAccess(redisClient, blobstore.CASReadBufferFactory, digest.KeyWithoutInstance, 0, false, 0, 0)
 
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -276,6 +276,11 @@ message RedisBlobAccessConfiguration {
   // instead of blocking. Defaults to ReadTimeout,
   // can be overidden (e.g, '300s').
   google.protobuf.Duration write_timeout = 12;
+
+  // If true, the TTL of keys will be refreshed when they are visited
+  // by Get or FindMissing, so that key_ttl will count from last
+  // use. Otherwise, key_ttl will count from first insert.
+  bool refresh_ttl_on_use = 13;
 }
 
 message RemoteBlobAccessConfiguration {


### PR DESCRIPTION
This makes the key_ttl feature be LRU-like instead of FIFO.