### PR TITLE
Prefer WaitForReady on grpc clients

### DIFF
--- a/pkg/grpc/base_client_factory.go
+++ b/pkg/grpc/base_client_factory.go
@@ -34,6 +34,10 @@ func (cf baseClientFactory) NewClientFromConfiguration(config *configuration.Cli
 
 	dialOptions := []grpc.DialOption{
 		grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
+		// We consistently prefer to wait for a connection rather than
+		// abort builds when there is a tcp error. Can be overridden
+		// on a per-call basis.
+		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	}
 	unaryInterceptors := []grpc.UnaryClientInterceptor{
 		grpc_prometheus.UnaryClientInterceptor,


### PR DESCRIPTION
This CallOption causes client calls to prefer to block when the
underlying transport is broken (any form of tcp connection issue)
rather than fail the call instantly with Unavailable. Deadlines are
still respected, but this will make grpc wait until the call deadline
is reached if a backend is not responding.

For bazel builds, we consistently prefer to take the latency hit of
waiting for a connection to recover rather than instantly failing the
build when any glitch happens.