### PR TITLE
configurable logging for aws-sdk-go

### DIFF
--- a/pkg/cloud/aws/session.go
+++ b/pkg/cloud/aws/session.go
@@ -31,5 +31,27 @@ func NewSessionFromConfiguration(configuration *aws_pb.SessionConfiguration) (*s
 			staticCredentials.SecretAccessKey,
 			"")
 	}
+	logLevel := aws.LogOff
+	if configuration.GetLogDebug() {
+		logLevel |= aws.LogDebug
+	}
+	if configuration.GetLogSigning() {
+		logLevel |= aws.LogDebugWithSigning
+	}
+	if configuration.GetLogHttpBody() {
+		logLevel |= aws.LogDebugWithHTTPBody
+	}
+	if configuration.GetLogRequestRetries() {
+		logLevel |= aws.LogDebugWithRequestRetries
+	}
+	if configuration.GetLogRequestErrors() {
+		logLevel |= aws.LogDebugWithRequestErrors
+	}
+	if configuration.GetLogEventStreamBody() {
+		logLevel |= aws.LogDebugWithEventStreamBody
+	}
+	if logLevel != aws.LogOff {
+		cfg.LogLevel = &logLevel
+	}
 	return session.NewSession(&cfg)
 }

--- a/pkg/proto/configuration/cloud/aws/aws.proto
+++ b/pkg/proto/configuration/cloud/aws/aws.proto
@@ -30,4 +30,13 @@ message SessionConfiguration {
   // will search the default credential provider chain (e.g.,
   // environment variables, EC2 instance IAM roles).
   StaticCredentials static_credentials = 5;
+
+  // Log levels are documented at
+  // https://docs.aws.amazon.com/sdk-for-go/api/aws/#LogLevelType
+  bool log_debug = 6;
+  bool log_signing = 7;
+  bool log_http_body = 8;
+  bool log_request_retries = 9;
+  bool log_request_errors = 10;
+  bool log_event_stream_body = 11;
 }


### PR DESCRIPTION
Wire up the aws-sdk-go logging options to the config file.