### PR TITLE
Convert the style and lint bits of github workflows into a runnable command

### DIFF
--- a/.github/workflows/master.yaml
+++ b/.github/workflows/master.yaml
@@ -9,36 +9,12 @@
                "uses": "actions/checkout@v1"
             },
             {
-               "name": "Buildifier",
-               "run": "bazel run @com_github_bazelbuild_buildtools//:buildifier"
-            },
-            {
-               "name": "Gazelle",
-               "run": "bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro go_dependencies.bzl%go_dependencies -prune && bazel run //:gazelle"
-            },
-            {
-               "name": "Gofmt",
-               "run": "bazel run @go_sdk//:bin/gofmt -- -s -w ."
-            },
-            {
-               "name": "Clang format",
-               "run": "find . -name '*.proto' -exec bazel run @llvm_toolchain//:bin/clang-format -- -i {} +"
-            },
-            {
-               "name": "GitHub workflows",
-               "run": "bazel build //tools/github_workflows && cp bazel-bin/tools/github_workflows/* .github/workflows"
+               "name": "Tidy and lint",
+               "run": "bazel run //tools/tidy"
             },
             {
                "name": "Test style conformance",
                "run": "git diff --exit-code HEAD --"
-            },
-            {
-               "name": "Golint",
-               "run": "bazel run @org_golang_x_lint//golint -- -set_exit_status $(pwd)/..."
-            },
-            {
-               "name": "Check for ineffective assignments",
-               "run": "bazel run @com_github_gordonklaus_ineffassign//:ineffassign $(pwd)"
             },
             {
                "name": "linux_amd64: build and test",

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -9,36 +9,12 @@
                "uses": "actions/checkout@v1"
             },
             {
-               "name": "Buildifier",
-               "run": "bazel run @com_github_bazelbuild_buildtools//:buildifier"
-            },
-            {
-               "name": "Gazelle",
-               "run": "bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro go_dependencies.bzl%go_dependencies -prune && bazel run //:gazelle"
-            },
-            {
-               "name": "Gofmt",
-               "run": "bazel run @go_sdk//:bin/gofmt -- -s -w ."
-            },
-            {
-               "name": "Clang format",
-               "run": "find . -name '*.proto' -exec bazel run @llvm_toolchain//:bin/clang-format -- -i {} +"
-            },
-            {
-               "name": "GitHub workflows",
-               "run": "bazel build //tools/github_workflows && cp bazel-bin/tools/github_workflows/* .github/workflows"
+               "name": "Tidy and lint",
+               "run": "bazel run //tools/tidy"
             },
             {
                "name": "Test style conformance",
                "run": "git diff --exit-code HEAD --"
-            },
-            {
-               "name": "Golint",
-               "run": "bazel run @org_golang_x_lint//golint -- -set_exit_status $(pwd)/..."
-            },
-            {
-               "name": "Check for ineffective assignments",
-               "run": "bazel run @com_github_gordonklaus_ineffassign//:ineffassign $(pwd)"
             },
             {
                "name": "linux_amd64: build and test",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -6,8 +6,10 @@ load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
 # gazelle:resolve proto go build/bazel/remote/execution/v2/remote_execution.proto @com_github_bazelbuild_remote_apis//build/bazel/remote/execution/v2:go_default_library
 gazelle(
     name = "gazelle",
+    visibility = ["//tools/tidy:__pkg__"],
 )
 
 buildifier(
     name = "buildifier",
+    visibility = ["//tools/tidy:__pkg__"],
 )

--- a/tools/github_workflows/BUILD.bazel
+++ b/tools/github_workflows/BUILD.bazel
@@ -13,5 +13,6 @@ jsonnet_to_json(
         "master.yaml",
         "pull-requests.yaml",
     ],
+    visibility = ["//tools/tidy:__pkg__"],
     deps = [":workflows_template"],
 )

--- a/tools/github_workflows/workflows_template.libsonnet
+++ b/tools/github_workflows/workflows_template.libsonnet
@@ -38,36 +38,12 @@
           uses: 'actions/checkout@v1',
         },
         {
-          name: 'Buildifier',
-          run: 'bazel run @com_github_bazelbuild_buildtools//:buildifier',
-        },
-        {
-          name: 'Gazelle',
-          run: 'bazel run //:gazelle -- update-repos -from_file=go.mod -to_macro go_dependencies.bzl%go_dependencies -prune && bazel run //:gazelle',
-        },
-        {
-          name: 'Gofmt',
-          run: 'bazel run @go_sdk//:bin/gofmt -- -s -w .',
-        },
-        {
-          name: 'Clang format',
-          run: "find . -name '*.proto' -exec bazel run @llvm_toolchain//:bin/clang-format -- -i {} +",
-        },
-        {
-          name: 'GitHub workflows',
-          run: 'bazel build //tools/github_workflows && cp bazel-bin/tools/github_workflows/* .github/workflows',
+          name: 'Tidy and lint',
+          run: 'bazel run //tools/tidy',
         },
         {
           name: 'Test style conformance',
           run: 'git diff --exit-code HEAD --',
-        },
-        {
-          name: 'Golint',
-          run: 'bazel run @org_golang_x_lint//golint -- -set_exit_status $(pwd)/...',
-        },
-        {
-          name: 'Check for ineffective assignments',
-          run: 'bazel run @com_github_gordonklaus_ineffassign//:ineffassign $(pwd)',
         },
       ] + std.flattenArrays([
         [{

--- a/tools/tidy/BUILD.bazel
+++ b/tools/tidy/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    data = [
+        "//:buildifier",
+        "//:gazelle-runner",
+        "//tools/github_workflows",
+        "@com_github_gordonklaus_ineffassign//:ineffassign",
+        "@go_sdk//:bin/gofmt",
+        "@llvm_toolchain//:bin/clang-format",
+        "@org_golang_x_lint//golint",
+    ],
+    importpath = "github.com/buildbarn/bb-storage/tools/tidy",
+    visibility = ["//visibility:private"],
+    deps = ["@io_bazel_rules_go//go/tools/bazel:go_default_library"],
+)
+
+go_binary(
+    name = "tidy",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)

--- a/tools/tidy/main.go
+++ b/tools/tidy/main.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+func doRun(abspath string, arg ...string) {
+	cmd := exec.Command(abspath, arg...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		log.Fatalf("%s failed: %v", abspath, err)
+	}
+}
+
+func run(path string, arg ...string) {
+	abspath, err := bazel.Runfile(path)
+	if err != nil {
+		log.Fatalf("%s not found in runfiles: %v", path, err)
+	}
+	doRun(abspath, arg...)
+}
+
+func runGo(pkg, name string, arg ...string) {
+	abspath, found := bazel.FindBinary(pkg, name)
+	if !found {
+		log.Fatalf("%s/%s not found in runfiles", pkg, name)
+	}
+	doRun(abspath, arg...)
+}
+
+func copyWorkflows(path, root string) {
+	abspath, err := bazel.Runfile(path)
+	if err != nil {
+		log.Fatal("could not find %s: %v", path, err)
+	}
+	contents, err := ioutil.ReadDir(abspath)
+	if err != nil {
+		log.Fatal("could not read %s: %v", abspath, err)
+	}
+	for _, info := range contents {
+		if !info.IsDir() {
+			inpath := filepath.Join(abspath, info.Name())
+			outpath := filepath.Join(root, ".github/workflows", info.Name())
+
+			data, err := ioutil.ReadFile(inpath)
+			if err != nil {
+				log.Fatal("could not read %s: %v", inpath, err)
+			}
+			err = ioutil.WriteFile(outpath, data, 0644)
+			if err != nil {
+				log.Fatal("could not write %s: %v", outpath, err)
+			}
+		}
+	}
+}
+
+func main() {
+	root := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	if root == "" {
+		log.Fatalf("invoke as bazel run //tools/tidy")
+	}
+	run("buildifier.bash")
+	run("gazelle-runner.bash", "-bazel_run", "update-repos", "-from_file=go.mod", "-to_macro", "go_dependencies.bzl%go_dependencies", "-prune")
+	run("gazelle-runner.bash", "-bazel_run")
+	run("../go_sdk/bin/gofmt", "-s", "-w", root)
+	if err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
+		if !info.IsDir() && strings.HasSuffix(info.Name(), ".proto") {
+			run("external/llvm_toolchain/bin/clang-format", "-i", path)
+		}
+		return nil
+	}); err != nil {
+		log.Fatalf("walking %s failed: %v", root, err)
+	}
+	runGo("../org_golang_x_lint/golint", "golint", "-set_exit_status", root+"/...")
+	runGo("../com_github_gordonklaus_ineffassign", "ineffassign", root)
+	copyWorkflows("tools/github_workflows", root)
+}


### PR DESCRIPTION
It's not pretty, and it's very much writing a shell script in golang,
but it lets me run the whole thing locally instead of repeatedly
pushing and waiting for the github workflow to tell me that I don't
quite have the formatting the way it wants.