### PR TITLE
Evict entries from existence cache when NotFound errors are seen

### DIFF
--- a/pkg/blobstore/existence_caching_blob_access_test.go
+++ b/pkg/blobstore/existence_caching_blob_access_test.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/buildbarn/bb-storage/internal/mock"
 	"github.com/buildbarn/bb-storage/pkg/blobstore"
+	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/eviction"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestExistenceCachingBlobAccessFindMissing(t *testing.T) {
@@ -52,4 +55,51 @@ func TestExistenceCachingBlobAccessFindMissing(t *testing.T) {
 	missing, err = blobAccess.FindMissing(ctx, bothDigests)
 	require.NoError(t, err)
 	require.Equal(t, nonExistingDigests, missing)
+}
+
+func TestExistenceCachingBlobAccessGetNotExists(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	baseBlobAccess := mock.NewMockBlobAccess(ctrl)
+	clock := mock.NewMockClock(ctrl)
+	blobAccess := blobstore.NewExistenceCachingBlobAccess(
+		baseBlobAccess,
+		digest.NewExistenceCache(clock, digest.KeyWithoutInstance, 10, time.Minute, eviction.NewLRUSet()))
+
+	digest1 := digest.MustNewDigest("instance", "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969", 5)
+	digest2 := digest.MustNewDigest("instance", "78ae647dc5544d227130a0682a51e30bc7777fbb6d8a8f17007463a3ecd1d524", 5)
+	bothDigests := digest.NewSetBuilder().Add(digest1).Add(digest2).Build()
+	oneDigest := digest.NewSetBuilder().Add(digest1).Build()
+
+	// Prime the cache
+	clock.EXPECT().Now().Return(time.Unix(1000, 0)).Times(2)
+	baseBlobAccess.EXPECT().FindMissing(ctx, bothDigests).Return(digest.EmptySet, nil)
+	missing, err := blobAccess.FindMissing(ctx, bothDigests)
+	require.NoError(t, err)
+	require.Equal(t, digest.EmptySet, missing)
+
+	// Query for digest 1, and return NotFound, evicting it
+	baseBlobAccess.EXPECT().Get(ctx, digest1).Return(buffer.NewBufferFromError(status.Error(codes.NotFound, "Blob not found")))
+	_, err = blobAccess.Get(ctx, digest1).ToByteSlice(100)
+	require.Equal(t, status.Error(codes.NotFound, "Blob not found"), err)
+
+	// Not enough time has elapsed for the cache to expire, but
+	// digest1 is still removed
+	clock.EXPECT().Now().Return(time.Unix(1030, 0)).Times(2)
+	baseBlobAccess.EXPECT().FindMissing(ctx, oneDigest).Return(oneDigest, nil)
+	missing, err = blobAccess.FindMissing(ctx, bothDigests)
+	require.NoError(t, err)
+	require.Equal(t, oneDigest, missing)
+
+	// Query for digest 2, and return Unavailable, not evicting it
+	baseBlobAccess.EXPECT().Get(ctx, digest2).Return(buffer.NewBufferFromError(status.Error(codes.Unavailable, "Server not responding")))
+	_, err = blobAccess.Get(ctx, digest2).ToByteSlice(100)
+	require.Equal(t, status.Error(codes.Unavailable, "Server not responding"), err)
+
+	// digest2 is still present
+	clock.EXPECT().Now().Return(time.Unix(1030, 0)).Times(2)
+	baseBlobAccess.EXPECT().FindMissing(ctx, oneDigest).Return(oneDigest, nil)
+	missing, err = blobAccess.FindMissing(ctx, bothDigests)
+	require.NoError(t, err)
+	require.Equal(t, oneDigest, missing)
 }

--- a/pkg/digest/existence_cache.go
+++ b/pkg/digest/existence_cache.go
@@ -82,3 +82,15 @@ func (ec *ExistenceCache) Add(digests Set) {
 	}
 	ec.lock.Unlock()
 }
+
+func (ec *ExistenceCache) Remove(digest Digest) {
+	ec.lock.Lock()
+	key := digest.GetKey(ec.keyFormat)
+	// Simply deleting would mess up the cache size handling above, so
+	// we zero the time instead. It will be evicted as usual, but will
+	// no longer affect the result of RemoveExisting
+	if _, ok := ec.insertionTimes[key]; ok {
+		ec.insertionTimes[key] = time.Time{}
+	}
+	ec.lock.Unlock()
+}

--- a/pkg/digest/existence_cache_test.go
+++ b/pkg/digest/existence_cache_test.go
@@ -109,4 +109,21 @@ func TestExistenceCache(t *testing.T) {
 		t,
 		allDigests,
 		existenceCache.RemoveExisting(allDigests))
+
+	// Add two elements, then remove one. The removed item should not
+	// be pruned.
+	clock.EXPECT().Now().Return(time.Unix(1100, 0))
+	existenceCache.Add(digest.NewSetBuilder().
+		Add(digests[0]).
+		Add(digests[1]).
+		Build())
+	existenceCache.Remove(digests[1])
+	clock.EXPECT().Now().Return(time.Unix(1101, 0))
+	require.Equal(
+		t,
+		digest.NewSetBuilder().
+			Add(digests[1]).
+			Add(digests[2]).
+			Build(),
+		existenceCache.RemoveExisting(allDigests))
 }


### PR DESCRIPTION
Storage backends signal that a cache item has been evicted by
returning NotFound. We can use this signal to clear the existence
cache immediately. Since bazel does retry FindMissing on each
execution attempt, this will result in the retry getting a correct
result and being able to proceed.

Where multiple parallel existence caches are used, --remote_retries will need to be larger than the number of caches for this to work.

Obviously this doesn't help in build-without-the-bytes mode if the lost cache entry is an execution result, but it should work for input files which bazel has available.