### PR TITLE
remove key_ttl from redis, it is worse than redis eviction

### DIFF
--- a/pkg/blobstore/configuration/new_blob_access.go
+++ b/pkg/blobstore/configuration/new_blob_access.go
@@ -175,14 +175,6 @@ func newNestedBlobAccessBare(configuration *pb.BlobAccessConfiguration, creator 
 			return BlobAccessInfo{}, "", util.StatusWrap(err, "Failed to obtain TLS configuration")
 		}
 
-		var keyTTL time.Duration
-		if backend.Redis.KeyTtl != nil {
-			keyTTL, err = ptypes.Duration(backend.Redis.KeyTtl)
-			if err != nil {
-				return BlobAccessInfo{}, "", util.StatusWrap(err, "Failed to obtain key TTL configuration")
-			}
-		}
-
 		var replicationTimeout time.Duration
 		if backend.Redis.ReplicationTimeout != nil {
 			replicationTimeout, err = ptypes.Duration(backend.Redis.ReplicationTimeout)
@@ -275,7 +267,6 @@ func newNestedBlobAccessBare(configuration *pb.BlobAccessConfiguration, creator 
 				redisClient,
 				readBufferFactory,
 				digestKeyFormat,
-				keyTTL,
 				backend.Redis.ReplicationCount,
 				replicationTimeout),
 			DigestKeyFormat: digestKeyFormat,

--- a/pkg/blobstore/redis_blob_access.go
+++ b/pkg/blobstore/redis_blob_access.go
@@ -26,19 +26,17 @@ type redisBlobAccess struct {
 	redisClient        RedisClient
 	readBufferFactory  ReadBufferFactory
 	digestKeyFormat    digest.KeyFormat
-	keyTTL             time.Duration
 	replicationCount   int64
 	replicationTimeout int
 }
 
 // NewRedisBlobAccess creates a BlobAccess that uses Redis as its
 // backing store.
-func NewRedisBlobAccess(redisClient RedisClient, readBufferFactory ReadBufferFactory, digestKeyFormat digest.KeyFormat, keyTTL time.Duration, replicationCount int64, replicationTimeout time.Duration) BlobAccess {
+func NewRedisBlobAccess(redisClient RedisClient, readBufferFactory ReadBufferFactory, digestKeyFormat digest.KeyFormat, replicationCount int64, replicationTimeout time.Duration) BlobAccess {
 	return &redisBlobAccess{
 		redisClient:        redisClient,
 		readBufferFactory:  readBufferFactory,
 		digestKeyFormat:    digestKeyFormat,
-		keyTTL:             keyTTL,
 		replicationCount:   int64(replicationCount),
 		replicationTimeout: int(replicationTimeout.Milliseconds()),
 	}
@@ -79,7 +77,7 @@ func (ba *redisBlobAccess) Put(ctx context.Context, digest digest.Digest, b buff
 	if err != nil {
 		return util.StatusWrapWithCode(err, codes.Unavailable, "Failed to put blob")
 	}
-	if err := ba.redisClient.Set(ctx, digest.GetKey(ba.digestKeyFormat), value, ba.keyTTL).Err(); err != nil {
+	if err := ba.redisClient.Set(ctx, digest.GetKey(ba.digestKeyFormat), value, 0).Err(); err != nil {
 		return util.StatusWrapWithCode(err, codes.Unavailable, "Failed to put blob")
 	}
 	return ba.waitIfReplicationEnabled(ctx)

--- a/pkg/blobstore/redis_blob_access_test.go
+++ b/pkg/blobstore/redis_blob_access_test.go
@@ -19,7 +19,7 @@ func TestRedisBlobAccessContextCanceled(t *testing.T) {
 	ctrl, ctx := gomock.WithContext(context.Background(), t)
 
 	redisClient := mock.NewMockRedisClient(ctrl)
-	blobAccess := blobstore.NewRedisBlobAccess(redisClient, blobstore.CASReadBufferFactory, digest.KeyWithoutInstance, 0, 0, 0)
+	blobAccess := blobstore.NewRedisBlobAccess(redisClient, blobstore.CASReadBufferFactory, digest.KeyWithoutInstance, 0, 0)
 
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -244,12 +244,9 @@ message RedisBlobAccessConfiguration {
   // when not set.
   buildbarn.configuration.tls.ClientConfiguration tls = 4;
 
-  // How long to keep a cache key in Redis, specified as a duration.
-  // When unset, this means keys do not expire and and rely on Redis
-  // eviction policy to efficiently remove keys when storage gets full.
-  // A reasonable number for this would allow keys to live long enough
-  // objects to be found in the CAS once the client uploads them.
-  google.protobuf.Duration key_ttl = 7;
+  // key_ttl was removed because it gives the wrong eviction
+  // behaviour. Use redis's own eviction policies instead.
+  reserved 7;
 
   // The minimum number of replicas to successfully replicate put calls to
   // before considering it successful.


### PR DESCRIPTION
key_ttl is FIFO eviction, which is just about the worst eviction behaviour we can achieve