### PR TITLE
Updating BlobReplicatorConfiguration 'remote' variable to 'grpc'.

### DIFF
--- a/pkg/blobstore/configuration/cas_blob_replicator_creator.go
+++ b/pkg/blobstore/configuration/cas_blob_replicator_creator.go
@@ -26,12 +26,12 @@ func NewCASBlobReplicatorCreator(grpcClientFactory grpc.ClientFactory) BlobRepli
 
 func (brc *casBlobReplicatorCreator) NewCustomBlobReplicator(configuration *pb.BlobReplicatorConfiguration, source blobstore.BlobAccess, sink BlobAccessInfo) (replication.BlobReplicator, error) {
 	switch mode := configuration.Mode.(type) {
-	case *pb.BlobReplicatorConfiguration_Remote:
-		client, err := brc.grpcClientFactory.NewClientFromConfiguration(mode.Remote)
+	case *pb.BlobReplicatorConfiguration_Grpc:
+		client, err := brc.grpcClientFactory.NewClientFromConfiguration(mode.Grpc)
 		if err != nil {
 			return nil, err
 		}
-		return replication.NewRemoteBlobReplicator(source, client), nil
+		return replication.NewGrpcBlobReplicator(source, client), nil
 	default:
 		return nil, status.Error(codes.InvalidArgument, "Configuration did not contain a supported replicator")
 	}

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -556,7 +556,7 @@ message BlobReplicatorConfiguration {
     //
     // This strategy is only supported for the Content Addressable
     // Storage.
-    buildbarn.configuration.grpc.ClientConfiguration remote = 2;
+    buildbarn.configuration.grpc.ClientConfiguration grpc = 2;
 
     // Queue and deduplicate all replication operations prior to
     // executing them.


### PR DESCRIPTION
This makes it consistent with BlobAccessConfiguration.