### PR TITLE
Add configurable window size

### DIFF
--- a/pkg/grpc/base_client_factory.go
+++ b/pkg/grpc/base_client_factory.go
@@ -62,6 +62,13 @@ func (cf baseClientFactory) NewClientFromConfiguration(config *configuration.Cli
 		dialOptions = append(dialOptions, grpc.WithInsecure())
 	}
 
+	if windowSize := config.InitialWindowSizeBytes; windowSize != 0 {
+		dialOptions = append(dialOptions, grpc.WithInitialWindowSize(windowSize))
+	}
+	if connWindowSize := config.InitialConnWindowSizeBytes; connWindowSize != 0 {
+		dialOptions = append(dialOptions, grpc.WithInitialConnWindowSize(connWindowSize))
+	}
+
 	// Optional: OAuth authentication.
 	if oauthConfig := config.Oauth; oauthConfig != nil {
 		var perRPC credentials.PerRPCCredentials

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -70,7 +70,6 @@ func NewServersFromConfigurationAndServe(configurations []*configuration.ServerC
 			serverOptions = append(serverOptions, grpc.InitialConnWindowSize(connWindowSize))
 		}
 
-
 		// Optional: Keepalive enforcement policy.
 		if policy := configuration.KeepaliveEnforcementPolicy; policy != nil {
 			minTime := policy.MinTime

--- a/pkg/grpc/server.go
+++ b/pkg/grpc/server.go
@@ -63,6 +63,14 @@ func NewServersFromConfigurationAndServe(configurations []*configuration.ServerC
 			serverOptions = append(serverOptions, grpc.MaxRecvMsgSize(int(maxRecvMsgSize)))
 		}
 
+		if windowSize := configuration.InitialWindowSizeBytes; windowSize != 0 {
+			serverOptions = append(serverOptions, grpc.InitialWindowSize(windowSize))
+		}
+		if connWindowSize := configuration.InitialConnWindowSizeBytes; connWindowSize != 0 {
+			serverOptions = append(serverOptions, grpc.InitialConnWindowSize(connWindowSize))
+		}
+
+
 		// Optional: Keepalive enforcement policy.
 		if policy := configuration.KeepaliveEnforcementPolicy; policy != nil {
 			minTime := policy.MinTime

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -76,10 +76,12 @@ message ClientConfiguration {
   // credentials.
   repeated string forward_and_reuse_metadata = 7;
 
-  // The gRPC connection's initial stream window size.  See grpc-go WithInitialWindowSize
+  // The gRPC connection's initial stream window size.  See grpc-go
+  // WithInitialWindowSize
   int32 initial_window_size_bytes = 8;
 
-  // The gRPC connection's initial connection window size.  See grpc-go WithInitialConnWindowSize
+  // The gRPC connection's initial connection window size.  See grpc-go
+  // WithInitialConnWindowSize
   int32 initial_conn_window_size_bytes = 9;
 }
 

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -152,10 +152,12 @@ message ServerConfiguration {
   // protocol.
   string health_check_service = 7;
 
-  // The gRPC connection's initial stream window size.  See grpc-go InitialWindowSize
+  // The gRPC connection's initial stream window size.  See grpc-go
+  // InitialWindowSize
   int32 initial_window_size_bytes = 8;
 
-  // The gRPC connection's initial connection window size.  See grpc-go InitialConnWindowSize
+  // The gRPC connection's initial connection window size.  See grpc-go
+  // InitialConnWindowSize
   int32 initial_conn_window_size_bytes = 9;
 }
 

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -75,6 +75,12 @@ message ClientConfiguration {
   // strongly discouraged, as it allows users to hijack each other's
   // credentials.
   repeated string forward_and_reuse_metadata = 7;
+
+  // The gRPC connection's initial stream window size.  See grpc-go WithInitialWindowSize
+  int32 initial_window_size_bytes = 8;
+
+  // The gRPC connection's initial connection window size.  See grpc-go WithInitialConnWindowSize
+  int32 initial_conn_window_size_bytes = 9;
 }
 
 message ClientKeepaliveConfiguration {
@@ -143,6 +149,12 @@ message ServerConfiguration {
   // report itself healthy for this service via the grpc.health.v1
   // protocol.
   string health_check_service = 7;
+
+  // The gRPC connection's initial stream window size.  See grpc-go InitialWindowSize
+  int32 initial_window_size_bytes = 8;
+
+  // The gRPC connection's initial connection window size.  See grpc-go InitialConnWindowSize
+  int32 initial_conn_window_size_bytes = 9;
 }
 
 message ServerKeepaliveEnforcementPolicy {


### PR DESCRIPTION
In my struggle to understand/optimize cache performance, I added these as configuration options to pass through to grpc.  I'm not sure if they make a difference or not, or if anyone else would use them, but cost in code is slight and will at least document here for anyone else troubleshooting.  Take or leave at your pleasure.

See also:
* https://github.com/jlaxson/bb-storage/pull/new/add-grpc-window-size
* https://pkg.go.dev/google.golang.org/grpc#WithInitialConnWindowSize and friends