### PR TITLE
Clarify the BlobAccessConfiguration.remote field comment

### DIFF
--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -27,7 +27,8 @@ message BlobAccessConfiguration {
     // Read objects from/write objects to a Redis server.
     RedisBlobAccessConfiguration redis = 2;
 
-    // Read objects from/write objects to a Bazel remote build cache server.
+    // Read objects from/write objects to a server that supports
+    // Bazel's HTTP caching protocol.
     RemoteBlobAccessConfiguration remote = 3;
 
     // Cache reads from a slow remote storage backend into a fast


### PR DESCRIPTION
The previous phrasing was ambiguous, since bazel supports two different cache protocols (HTTP and gRPC) and this field only
supports one of them (the term "HTTP caching protocol" is used in bazel's docs).

https://docs.bazel.build/versions/main/remote-caching.html#http-caching-protocol