### PR TITLE
Add support for compiling on Apple M1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -158,7 +158,11 @@ http_archive(
     urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/3.7.0/rules_nodejs-3.7.0.tar.gz"],
 )
 
-load("@build_bazel_rules_nodejs//:index.bzl", "npm_install")
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories", "npm_install")
+
+node_repositories(
+    node_version = "16.4.1",
+)
 
 npm_install(
     name = "npm",


### PR DESCRIPTION
It seems like only a small change is required in order to compile on darwin_arm64 i.e Apple M1 HW.

The node package supports darwin_arm64 from version 16+ so this PR will increment the node_version
to the latest supported version by the currently pointed out rules_nodejs.

The same change will also need to be made in the bb-remote-execution repository but I suppose
this should go in first and then a bump of the go_dependencies in the bb-remote-execution after that.