### PR TITLE
Forward gRPC context in the demultiplexing build queue

### DIFF
--- a/pkg/builder/configuration.go
+++ b/pkg/builder/configuration.go
@@ -44,13 +44,13 @@ func NewDemultiplexingBuildQueueFromConfiguration(schedulers map[string]*pb.Sche
 		})
 	}
 
-	return NewDemultiplexingBuildQueue(func(instanceName digest.InstanceName) (BuildQueue, digest.InstanceName, digest.InstanceName, error) {
+	return NewDemultiplexingBuildQueue(func(ctx context.Context, instanceName digest.InstanceName) (BuildQueue, digest.InstanceName, digest.InstanceName, error) {
 		if idx := buildQueuesTrie.GetLongestPrefix(instanceName); idx >= 0 {
 			// The instance name corresponds to a scheduler
 			// to which we can forward requests.
 			return buildQueues[idx].backend, buildQueues[idx].backendName, buildQueues[idx].instanceNamePatcher.PatchInstanceName(instanceName), nil
 		}
-		if err := auth.AuthorizeSingleInstanceName(context.Background(), nonExecutableInstanceNameAuthorizer, instanceName); err != nil {
+		if err := auth.AuthorizeSingleInstanceName(ctx, nonExecutableInstanceNameAuthorizer, instanceName); err != nil {
 			return nil, digest.EmptyInstanceName, digest.EmptyInstanceName, util.StatusWrapf(err, "This instance name does not provide remote execution, nor can the caller be authorized to do remote caching")
 		}
 		// The instance name does not correspond to a

--- a/pkg/builder/demultiplexing_build_queue.go
+++ b/pkg/builder/demultiplexing_build_queue.go
@@ -16,7 +16,7 @@ import (
 // DemultiplexedBuildQueueGetter is the callback invoked by the
 // demultiplexing build queue to obtain a backend that matches the
 // instance name that is provided.
-type DemultiplexedBuildQueueGetter func(instanceName digest.InstanceName) (BuildQueue, digest.InstanceName, digest.InstanceName, error)
+type DemultiplexedBuildQueueGetter func(ctx context.Context, instanceName digest.InstanceName) (BuildQueue, digest.InstanceName, digest.InstanceName, error)
 
 type demultiplexingBuildQueue struct {
 	getBackend DemultiplexedBuildQueueGetter
@@ -44,7 +44,7 @@ func (bq *demultiplexingBuildQueue) GetCapabilities(ctx context.Context, in *rem
 	if err != nil {
 		return nil, util.StatusWrapf(err, "Invalid instance name %#v", in.InstanceName)
 	}
-	backend, _, newInstanceName, err := bq.getBackend(instanceName)
+	backend, _, newInstanceName, err := bq.getBackend(ctx, instanceName)
 	if err != nil {
 		return nil, util.StatusWrapf(err, "Failed to obtain backend for instance name %#v", instanceName.String())
 	}
@@ -59,7 +59,7 @@ func (bq *demultiplexingBuildQueue) Execute(in *remoteexecution.ExecuteRequest, 
 	if err != nil {
 		return util.StatusWrapf(err, "Invalid instance name %#v", in.InstanceName)
 	}
-	backend, backendName, newInstanceName, err := bq.getBackend(instanceName)
+	backend, backendName, newInstanceName, err := bq.getBackend(out.Context(), instanceName)
 	if err != nil {
 		return util.StatusWrapf(err, "Failed to obtain backend for instance name %#v", instanceName.String())
 	}
@@ -81,7 +81,7 @@ func (bq *demultiplexingBuildQueue) WaitExecution(in *remoteexecution.WaitExecut
 	if err != nil {
 		return util.StatusWrapf(err, "Invalid instance name %#v", target[0])
 	}
-	backend, _, _, err := bq.getBackend(instanceName)
+	backend, _, _, err := bq.getBackend(out.Context(), instanceName)
 	if err != nil {
 		return util.StatusWrapf(err, "Failed to obtain backend for instance name %#v", instanceName.String())
 	}


### PR DESCRIPTION
Without forwarding of the gRPC context, authentication context gets lost. This can, for example, lead to failing calls to `GetCapabilities`, even when bb-storage is configured without any scheduler.