### PR TITLE
Postpone healthy service status response a bit

### DIFF
--- a/cmd/bb_replicator/main.go
+++ b/cmd/bb_replicator/main.go
@@ -57,15 +57,13 @@ func main() {
 		log.Fatal("Failed to create replicator: ", err)
 	}
 
-	go func() {
-		log.Fatal(
-			"gRPC server failure: ",
-			bb_grpc.NewServersFromConfigurationAndServe(
-				configuration.GrpcServers,
-				func(s grpc.ServiceRegistrar) {
-					replicator_pb.RegisterReplicatorServer(s, replication.NewReplicatorServer(replicator))
-				}))
-	}()
+	if err := bb_grpc.NewServersFromConfigurationAndServe(
+		configuration.GrpcServers,
+		func(s grpc.ServiceRegistrar) {
+			replicator_pb.RegisterReplicatorServer(s, replication.NewReplicatorServer(replicator))
+		}); err != nil {
+		log.Fatal("gRPC server failure: ", err)
+	}
 
 	lifecycleState.MarkReadyAndWait()
 }

--- a/cmd/bb_storage/main.go
+++ b/cmd/bb_storage/main.go
@@ -143,56 +143,54 @@ func main() {
 		capabilitiesProviders = append(capabilitiesProviders, buildQueue)
 	}
 
-	go func() {
-		log.Fatal(
-			"gRPC server failure: ",
-			bb_grpc.NewServersFromConfigurationAndServe(
-				configuration.GrpcServers,
-				func(s grpc.ServiceRegistrar) {
-					if contentAddressableStorage != nil {
-						remoteexecution.RegisterContentAddressableStorageServer(
-							s,
-							grpcservers.NewContentAddressableStorageServer(
-								contentAddressableStorage,
-								configuration.MaximumMessageSizeBytes))
-						bytestream.RegisterByteStreamServer(
-							s,
-							grpcservers.NewByteStreamServer(
-								contentAddressableStorage,
-								1<<16))
-					}
-					if actionCache != nil {
-						remoteexecution.RegisterActionCacheServer(
-							s,
-							grpcservers.NewActionCacheServer(
-								actionCache,
-								int(configuration.MaximumMessageSizeBytes)))
-					}
-					if indirectContentAddressableStorage != nil {
-						icas.RegisterIndirectContentAddressableStorageServer(
-							s,
-							grpcservers.NewIndirectContentAddressableStorageServer(
-								indirectContentAddressableStorage,
-								int(configuration.MaximumMessageSizeBytes)))
-					}
-					if initialSizeClassCache != nil {
-						iscc.RegisterInitialSizeClassCacheServer(
-							s,
-							grpcservers.NewInitialSizeClassCacheServer(
-								initialSizeClassCache,
-								int(configuration.MaximumMessageSizeBytes)))
-					}
-					if buildQueue != nil {
-						remoteexecution.RegisterExecutionServer(s, buildQueue)
-					}
-					if len(capabilitiesProviders) > 0 {
-						remoteexecution.RegisterCapabilitiesServer(
-							s,
-							capabilities.NewServer(
-								capabilities.NewMergingProvider(capabilitiesProviders)))
-					}
-				}))
-	}()
+	if err := bb_grpc.NewServersFromConfigurationAndServe(
+		configuration.GrpcServers,
+		func(s grpc.ServiceRegistrar) {
+			if contentAddressableStorage != nil {
+				remoteexecution.RegisterContentAddressableStorageServer(
+					s,
+					grpcservers.NewContentAddressableStorageServer(
+						contentAddressableStorage,
+						configuration.MaximumMessageSizeBytes))
+				bytestream.RegisterByteStreamServer(
+					s,
+					grpcservers.NewByteStreamServer(
+						contentAddressableStorage,
+						1<<16))
+			}
+			if actionCache != nil {
+				remoteexecution.RegisterActionCacheServer(
+					s,
+					grpcservers.NewActionCacheServer(
+						actionCache,
+						int(configuration.MaximumMessageSizeBytes)))
+			}
+			if indirectContentAddressableStorage != nil {
+				icas.RegisterIndirectContentAddressableStorageServer(
+					s,
+					grpcservers.NewIndirectContentAddressableStorageServer(
+						indirectContentAddressableStorage,
+						int(configuration.MaximumMessageSizeBytes)))
+			}
+			if initialSizeClassCache != nil {
+				iscc.RegisterInitialSizeClassCacheServer(
+					s,
+					grpcservers.NewInitialSizeClassCacheServer(
+						initialSizeClassCache,
+						int(configuration.MaximumMessageSizeBytes)))
+			}
+			if buildQueue != nil {
+				remoteexecution.RegisterExecutionServer(s, buildQueue)
+			}
+			if len(capabilitiesProviders) > 0 {
+				remoteexecution.RegisterCapabilitiesServer(
+					s,
+					capabilities.NewServer(
+						capabilities.NewMergingProvider(capabilitiesProviders)))
+			}
+		}); err != nil {
+		log.Fatal("gRPC server failure: ", err)
+	}
 
 	lifecycleState.MarkReadyAndWait()
 }


### PR DESCRIPTION
The healthy and serving status, i.e. HTTP `/-/healthy` and `grpc_health_v1.HealthCheckResponse_SERVING`, will now be postponed until the whole service is up and running. Before, the healthy status was potentially reported before starting to listen to the gRPC ports.

This removes an error mode where Kubernetes would believe that the service was ready just before it crashed. The previous behaviour could lead to a cluster being upgraded to an erroneous state even for a simple jsonnet configuration error.

(I think this was the problem, don't remember exactly how it did behave.)