### PR TITLE
Remove panic after graceful shutdown

### DIFF
--- a/pkg/global/graceful_termination_handler.go
+++ b/pkg/global/graceful_termination_handler.go
@@ -49,7 +49,10 @@ func InstallGracefulTerminationHandler() (context.Context, *errgroup.Group) {
 		if err := process.Signal(receivedSignal); err != nil {
 			panic(err)
 		}
-		panic("Raising the original signal didn't cause us to shut down")
+		// This code should not be reached, if it weren't for the
+		// fact that process.Signal() does not guarantee that the
+		// signal is delivered to the same thread.
+		// More details: https://github.com/golang/go/issues/19326
 	}()
 
 	return ctx, &group


### PR DESCRIPTION
remote-apis-testing shows the following log in https://gitlab.com/remote-apis-testing/remote-apis-testing/-/jobs/2773967861

```
2022/07/26 20:20:14 Received terminated signal. Initiating graceful shutdown.
2022/07/26 20:20:14 Graceful shutdown complete
panic: Raising the original signal didn't cause us to shut down
```

Apparently, the panic line was reached before the signal had been handled and the process killed, so just remove it.