### PR TITLE
Add missing storage_type metric label to various blobstore metrics

### DIFF
--- a/pkg/blobstore/configuration/new_blob_access.go
+++ b/pkg/blobstore/configuration/new_blob_access.go
@@ -338,7 +338,8 @@ func (nc *simpleNestedBlobAccessCreator) newNestedBlobAccessBare(configuration *
 				cachedReadBufferFactory,
 				sectorSizeBytes,
 				blockSectorCount,
-				int(blockCount))
+				int(blockCount),
+				storageTypeName)
 		default:
 			return BlobAccessInfo{}, "", status.Error(codes.InvalidArgument, "Blocks backend not specified")
 		}

--- a/pkg/blobstore/local/block_device_backed_block_allocator_test.go
+++ b/pkg/blobstore/local/block_device_backed_block_allocator_test.go
@@ -21,7 +21,7 @@ func TestBlockDeviceBackedBlockAllocator(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	blockDevice := mock.NewMockBlockDevice(ctrl)
-	pa := local.NewBlockDeviceBackedBlockAllocator(blockDevice, blobstore.CASReadBufferFactory, 1, 100, 10)
+	pa := local.NewBlockDeviceBackedBlockAllocator(blockDevice, blobstore.CASReadBufferFactory, 1, 100, 10, "cas")
 
 	// Based on the size of the allocator, it should be possible to
 	// create ten blocks.
@@ -143,7 +143,7 @@ func TestBlockDeviceBackedBlockAllocatorSectorSize(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
 	blockDevice := mock.NewMockBlockDevice(ctrl)
-	pa := local.NewBlockDeviceBackedBlockAllocator(blockDevice, blobstore.CASReadBufferFactory, 16, 100, 1)
+	pa := local.NewBlockDeviceBackedBlockAllocator(blockDevice, blobstore.CASReadBufferFactory, 16, 100, 1, "cas")
 
 	block, location, err := pa.NewBlock()
 	require.NoError(t, err)


### PR DESCRIPTION
Various `buildbarn_blobstore_block_device_backed_block_allocator*` metrics had the missing storage_type metric, which meant that various storage types were being combined together.

Closes #138