### PR TITLE
Switch to static base image with Busybox shell

### DIFF
--- a/cmd/bb_storage/BUILD.bazel
+++ b/cmd/bb_storage/BUILD.bazel
@@ -36,8 +36,8 @@ go_binary(
 
 go_image(
     name = "bb_storage_container",
+    base = "@go_debug_image_static//image",
     embed = [":bb_storage_lib"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
This pull-request fixes the issue #153. In case for the Buildbarn developers it's still a goal to provide bb_storage images including a shell-like environment the underlying base image needs to be changed. From a user perspective having a shell available in a bb-storage container simplifies debugging in cloud environments a lot.