### PR TITLE
Improve configuration error message for persistent directory

### DIFF
--- a/pkg/blobstore/configuration/new_blob_access.go
+++ b/pkg/blobstore/configuration/new_blob_access.go
@@ -357,12 +357,12 @@ func (nc *simpleNestedBlobAccessCreator) newNestedBlobAccessBare(configuration *
 			// persistent state from disk.
 			persistentStateDirectory, err := filesystem.NewLocalDirectory(persistent.StateDirectoryPath)
 			if err != nil {
-				return BlobAccessInfo{}, "", util.StatusWrap(err, "Failed to open persistent state directory")
+				return BlobAccessInfo{}, "", util.StatusWrapf(err, "Failed to open persistent state directory %#v", persistent.StateDirectoryPath)
 			}
 			persistentStateStore := local.NewDirectoryBackedPersistentStateStore(persistentStateDirectory)
 			persistentState, err := persistentStateStore.ReadPersistentState()
 			if err != nil {
-				return BlobAccessInfo{}, "", util.StatusWrap(err, "Failed to reload persistent state")
+				return BlobAccessInfo{}, "", util.StatusWrapf(err, "Failed to reload persistent state from %#v", persistent.StateDirectoryPath)
 			}
 			keyLocationMapHashInitialization = persistentState.KeyLocationMapHashInitialization
 


### PR DESCRIPTION
Consider a misconfiguration as follows:

    persistent: {}

Before this misconfiguration would give the same error as if it was configured but had filesystem problems.

    storage-0_1                 | 2023/03/14 10:13:51
    Failed to create Content Addressable Storage: rpc error: code = Unknown
    desc = Failed to open persistent state directory: no such file or directory

By writing the path in the error message, the error will hopefully be easier to track down.