### PR TITLE
build: Modify patch to remote-apis for greater compatibility

### DIFF
--- a/patches/com_github_bazelbuild_remote_apis/golang.diff
+++ b/patches/com_github_bazelbuild_remote_apis/golang.diff
@@ -1,15 +1,79 @@
-diff --git build/bazel/remote/execution/v2/BUILD build/bazel/remote/execution/v2/BUILD
-index 01f415b..ab7823a 100644
---- build/bazel/remote/execution/v2/BUILD
-+++ build/bazel/remote/execution/v2/BUILD
-@@ -1,5 +1,7 @@
- package(default_visibility = ["//visibility:public"])
- 
+diff --git build/bazel/remote/asset/v1/BUILD build/bazel/remote/asset/v1/BUILD
+index a09bea4..418fe05 100644
+--- build/bazel/remote/asset/v1/BUILD
++++ build/bazel/remote/asset/v1/BUILD
+@@ -1,7 +1,9 @@
+-package(default_visibility = ["//visibility:public"])
+-
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
  load("@rules_proto//proto:defs.bzl", "proto_library")
  
++package(default_visibility = ["//visibility:public"])
++
  licenses(["notice"])
+ 
+ proto_library(
+@@ -11,28 +13,25 @@ proto_library(
+         "//build/bazel/remote/execution/v2:remote_execution_proto",
+         "@com_google_protobuf//:duration_proto",
+         "@com_google_protobuf//:timestamp_proto",
+-        "@googleapis//:google_api_annotations_proto",
+-        "@googleapis//:google_api_http_proto",
+-        "@googleapis//:google_rpc_status_proto",
++        "@go_googleapis//google/api:annotations_proto",
++        "@go_googleapis//google/rpc:status_proto",
+     ],
+ )
+ 
+-alias(
+-    name = "remote_asset_java_proto",
+-    actual = "//build/bazel/remote/asset/v1/java:remote_asset_java_proto",
+-)
+-
+-alias(
+-    name = "remote_asset_cc_proto",
+-    actual = "//build/bazel/remote/asset/v1/cc:remote_asset_cc_grpc",
+-)
+-
+-alias(
++go_proto_library(
+     name = "remote_asset_go_proto",
+-    actual = "//build/bazel/remote/asset/v1/go:remote_asset_go_proto",
++    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
++    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1",
++    proto = ":remote_asset_proto",
++    deps = [
++        "//build/bazel/remote/execution/v2:execution",
++        "@go_googleapis//google/api:annotations_go_proto",
++        "@go_googleapis//google/rpc:status_go_proto",
++    ],
+ )
+ 
+-alias(
+-    name = "go_default_library",
+-    actual = "//build/bazel/remote/asset/v1/go:go_default_library",
++go_library(
++    name = "asset",
++    embed = [":remote_asset_go_proto"],
++    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/asset/v1",
+ )
+diff --git build/bazel/remote/execution/v2/BUILD build/bazel/remote/execution/v2/BUILD
+index 01f415b..fdd40c7 100644
+--- build/bazel/remote/execution/v2/BUILD
++++ build/bazel/remote/execution/v2/BUILD
+@@ -1,7 +1,9 @@
+-package(default_visibility = ["//visibility:public"])
+-
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+ load("@rules_proto//proto:defs.bzl", "proto_library")
+ 
++package(default_visibility = ["//visibility:public"])
++
+ licenses(["notice"])
+ 
+ proto_library(
 @@ -13,29 +15,27 @@ proto_library(
          "@com_google_protobuf//:duration_proto",
          "@com_google_protobuf//:timestamp_proto",
@@ -35,10 +99,9 @@ index 01f415b..ab7823a 100644
 -)
 -
 -alias(
--    name = "remote_execution_go_proto",
--    actual = "//build/bazel/remote/execution/v2/go:remote_execution_go_proto",
 +go_proto_library(
-+    name = "remote_execution_go_proto",
+     name = "remote_execution_go_proto",
+-    actual = "//build/bazel/remote/execution/v2/go:remote_execution_go_proto",
 +    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
 +    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
 +    proto = ":remote_execution_proto",

--- a/patches/com_github_bazelbuild_remote_apis/golang.diff
+++ b/patches/com_github_bazelbuild_remote_apis/golang.diff
@@ -38,7 +38,7 @@ index 01f415b..ab7823a 100644
 -    name = "remote_execution_go_proto",
 -    actual = "//build/bazel/remote/execution/v2/go:remote_execution_go_proto",
 +go_proto_library(
-+    name = "remoteexecution_go_proto",
++    name = "remote_execution_go_proto",
 +    compilers = ["@io_bazel_rules_go//proto:go_grpc"],
 +    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
 +    proto = ":remote_execution_proto",
@@ -55,7 +55,7 @@ index 01f415b..ab7823a 100644
 -    actual = "//build/bazel/remote/execution/v2/go:go_default_library",
 +go_library(
 +    name = "execution",
-+    embed = [":remoteexecution_go_proto"],
++    embed = [":remote_execution_go_proto"],
 +    importpath = "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2",
  )
 diff --git build/bazel/semver/BUILD build/bazel/semver/BUILD


### PR DESCRIPTION
This change modifies the patch to the `bazelbuild/remote-apis` repo to also (re)generate code for `remote_asset.proto`, so that bazelbuild/bb-remote-asset can share this patch, and use a library built from codegen run with a recent (and patched) version of protoc-gen-go (that generates types that takes a `ServiceRegistrar` in generated `Register*` methods instead of a concrete `*grpc.Server`).

Tested: `bazel test //...` still passes on my system