### PR TITLE
Return back improved key_ttl

### DIFF
--- a/pkg/blobstore/configuration/new_blob_access.go
+++ b/pkg/blobstore/configuration/new_blob_access.go
@@ -99,6 +99,14 @@ func (nc *simpleNestedBlobAccessCreator) newNestedBlobAccessBare(configuration *
 			return BlobAccessInfo{}, "", util.StatusWrap(err, "Failed to obtain TLS configuration")
 		}
 
+		var keyTTL time.Duration
+		if backend.Redis.KeyTtl != nil {
+			if err := backend.Redis.DialTimeout.CheckValid(); err != nil {
+				return BlobAccessInfo{}, "", util.StatusWrap(err, "Failed to obtain key TTL configuration")
+			}
+			keyTTL = backend.Redis.KeyTtl.AsDuration()
+		}
+
 		var replicationTimeout time.Duration
 		if backend.Redis.ReplicationTimeout != nil {
 			if err := backend.Redis.ReplicationTimeout.CheckValid(); err != nil {
@@ -191,6 +199,7 @@ func (nc *simpleNestedBlobAccessCreator) newNestedBlobAccessBare(configuration *
 				redisClient,
 				readBufferFactory,
 				digestKeyFormat,
+				keyTTL,
 				backend.Redis.ReplicationCount,
 				replicationTimeout,
 				creator.GetDefaultCapabilitiesProvider()),

--- a/pkg/blobstore/redis_blob_access_test.go
+++ b/pkg/blobstore/redis_blob_access_test.go
@@ -21,7 +21,7 @@ func TestRedisBlobAccessContextCanceled(t *testing.T) {
 
 	redisClient := mock.NewMockRedisClient(ctrl)
 	capabilitiesProvider := mock.NewMockCapabilitiesProvider(ctrl)
-	blobAccess := blobstore.NewRedisBlobAccess(redisClient, blobstore.CASReadBufferFactory, digest.KeyWithoutInstance, 0, 0, capabilitiesProvider)
+	blobAccess := blobstore.NewRedisBlobAccess(redisClient, blobstore.CASReadBufferFactory, digest.KeyWithoutInstance, 0, 0, 0, capabilitiesProvider)
 
 	canceledCtx, cancel := context.WithCancel(ctx)
 	cancel()

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -292,9 +292,14 @@ message RedisBlobAccessConfiguration {
   // when not set.
   buildbarn.configuration.tls.ClientConfiguration tls = 4;
 
-  // key_ttl was removed because it gives the wrong eviction
-  // behaviour. Use redis's own eviction policies instead.
-  reserved 7;
+  // How long to keep a cache key in Redis, specified as a duration.
+  // When unset, this means keys do not expire and and rely on Redis
+  // eviction policy to efficiently remove keys when storage gets full.
+  // A reasonable number for this would allow keys to live long enough
+  // objects to be found in the CAS once the client uploads them.
+  // TTL is set on Put() method and updated every time object 
+  // is accessed by Get() and FindMissing() methods.
+  google.protobuf.Duration key_ttl = 7;
 
   // The minimum number of replicas to successfully replicate put calls to
   // before considering it successful.


### PR DESCRIPTION
When updating on a new version of buildbarn, I've noticed, that you removed `key_ttl` from redis blob access implementation. But we relied on that field, using our own patch, so I decided to try to merge it in main buildbarn repository.

The idea is that we want to update TTL (using EXPIRE command) every time we access an object through Get() or FindMissing(). If `key_ttl` wasn't set, we still want to TOUCH it, so that redis would not remove it because of old access time before we are able to download it.