### PR TITLE
feat: publish multi-arch images

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -12,9 +12,21 @@ http_archive(
 )
 
 http_archive(
-    name = "io_bazel_rules_docker",
-    sha256 = "b1e80761a8a8243d03ebca8845e9cc1ba6c82ce7c5179ce2b295cd36f7e394bf",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.25.0/rules_docker-v0.25.0.tar.gz"],
+    name = "aspect_bazel_lib",
+    sha256 = "6c25c59581041ede31e117693047f972cc4700c89acf913658dc89d04c338f8d",
+    strip_prefix = "bazel-lib-2.5.3",
+    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.5.3/bazel-lib-v2.5.3.tar.gz",
+)
+
+load("@aspect_bazel_lib//lib:repositories.bzl", "register_expand_template_toolchains")
+
+register_expand_template_toolchains()
+
+http_archive(
+    name = "rules_oci",
+    sha256 = "4a276e9566c03491649eef63f27c2816cc222f41ccdebd97d2c5159e84917c3b",
+    strip_prefix = "rules_oci-1.7.4",
+    url = "https://github.com/bazel-contrib/rules_oci/releases/download/v1.7.4/rules_oci-v1.7.4.tar.gz",
 )
 
 http_archive(
@@ -36,7 +48,7 @@ http_archive(
     ],
 )
 
-load("@bazel_gazelle//:deps.bzl", "go_repository")
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
 # Override the version of gomock to one that includes support for
 # generating mocks for function types. We can't do this through go.mod,
@@ -61,21 +73,31 @@ go_rules_dependencies()
 
 go_register_toolchains(version = "1.21.5")
 
-load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
+load("@rules_oci//oci:pull.bzl", "oci_pull")
+load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
 
-container_repositories()
+oci_register_toolchains(
+    name = "oci",
+    crane_version = LATEST_CRANE_VERSION,
+)
 
-load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
-
-container_deps()
-
-load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
+# NB: this base image is chosen to exactly match what we had when using rules_docker
+# prior to March 2024:
+# $ bazel query --output=build @go_image_static//image:image
+# container_import(
+#   name = "image",
+#   base_image_digest = "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4",
+#   base_image_registry = "gcr.io",
+#   base_image_repository = "distroless/static",
+# )
+oci_pull(
+    name = "distroless_static",
+    digest = "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4",
+    image = "gcr.io/distroless/static",
+    platforms = ["linux/amd64","linux/arm64"],
+)
 
 gazelle_dependencies()
-
-load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
-
-_go_image_repos()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -73,6 +73,8 @@ go_rules_dependencies()
 
 go_register_toolchains(version = "1.21.5")
 
+gazelle_dependencies()
+
 load("@rules_oci//oci:pull.bzl", "oci_pull")
 load("@rules_oci//oci:repositories.bzl", "LATEST_CRANE_VERSION", "oci_register_toolchains")
 
@@ -100,8 +102,6 @@ oci_pull(
         "linux/arm64",
     ],
 )
-
-gazelle_dependencies()
 
 http_archive(
     name = "com_github_bazelbuild_buildtools",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -81,7 +81,7 @@ oci_register_toolchains(
     crane_version = LATEST_CRANE_VERSION,
 )
 
-# NB: this base image is chosen to exactly match what we had when using rules_docker
+# NB: this base image is chosen to match what we had when using rules_docker
 # prior to March 2024:
 # $ bazel query --output=build @go_image_static//image:image
 # container_import(
@@ -91,9 +91,10 @@ oci_register_toolchains(
 #   base_image_repository = "distroless/static",
 # )
 oci_pull(
-    name = "distroless_base",
+    name = "distroless_static",
+    # Note, we cannot use the same digest as it didn't have an arm64 entry in the index
     digest = "sha256:ccaef5ee2f1850270d453fdf700a5392534f8d1a8ca2acda391fbb6a06b81c86",
-    image = "gcr.io/distroless/base",
+    image = "gcr.io/distroless/static",
     platforms = [
         "linux/amd64",
         "linux/arm64",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -94,12 +94,12 @@ oci_register_toolchains(
 # )
 oci_pull(
     name = "distroless_static",
-    # Note, we cannot use the same digest as it didn't have an arm64 entry in the index
-    digest = "sha256:ccaef5ee2f1850270d453fdf700a5392534f8d1a8ca2acda391fbb6a06b81c86",
+    #NB: cannot use the same digest as above, as it predates having an arm64 entry in the index
+    digest = "sha256:7e5c6a2a4ae854242874d36171b31d26e0539c98fc6080f942f16b03e82851ab",
     image = "gcr.io/distroless/static",
     platforms = [
         "linux/amd64",
-        "linux/arm64",
+        "linux/arm64/v8",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,18 +83,8 @@ oci_register_toolchains(
     crane_version = LATEST_CRANE_VERSION,
 )
 
-# NB: this base image is chosen to match what we had when using rules_docker
-# prior to March 2024:
-# $ bazel query --output=build @go_image_static//image:image
-# container_import(
-#   name = "image",
-#   base_image_digest = "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4",
-#   base_image_registry = "gcr.io",
-#   base_image_repository = "distroless/static",
-# )
 oci_pull(
     name = "distroless_static",
-    #NB: cannot use the same digest as above, as it predates having an arm64 entry in the index
     digest = "sha256:7e5c6a2a4ae854242874d36171b31d26e0539c98fc6080f942f16b03e82851ab",
     image = "gcr.io/distroless/static",
     platforms = [

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,10 +91,13 @@ oci_register_toolchains(
 #   base_image_repository = "distroless/static",
 # )
 oci_pull(
-    name = "distroless_static",
-    digest = "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4",
-    image = "gcr.io/distroless/static",
-    platforms = ["linux/amd64","linux/arm64"],
+    name = "distroless_base",
+    digest = "sha256:ccaef5ee2f1850270d453fdf700a5392534f8d1a8ca2acda391fbb6a06b81c86",
+    image = "gcr.io/distroless/base",
+    platforms = [
+        "linux/amd64",
+        "linux/arm64",
+    ],
 )
 
 gazelle_dependencies()

--- a/cmd/bb_copy/BUILD.bazel
+++ b/cmd/bb_copy/BUILD.bazel
@@ -1,6 +1,7 @@
-load("//tools:container.bzl", "container_push_official")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//tools:container.bzl", "container_push_official")
 
 go_library(
     name = "bb_copy_lib",
@@ -20,18 +21,43 @@ go_library(
     ],
 )
 
-go_binary(
-    name = "bb_copy",
-    embed = [":bb_copy_lib"],
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
+[
+    go_binary(
+        name = "bb_copy-{}".format(goarch),
+        embed = [":bb_copy_lib"],
+        pure = "on",
+        goarch = goarch,
+        goos = "linux",
+        visibility = ["//visibility:public"],
+    )
+    for goarch in ["amd64", "arm64"]
+]
 
-go_image(
+[
+    pkg_tar(
+        name = "tar-{}".format(goarch),
+        srcs = ["bb_copy-{}".format(goarch)],
+        package_dir = "/app/cmd/bb_storage",
+    )
+    for goarch in ["amd64", "arm64"]
+]
+
+[
+    oci_image(
+        name = "image-{}".format(goarch),
+        base = "@distroless_static",
+        entrypoint = ["/app/cmd/bb_storage/bb_copy-{}".format(goarch)],
+        tars = ["tar-{}".format(goarch)],
+    )
+    for goarch in ["amd64", "arm64"]
+]
+
+oci_image_index(
     name = "bb_copy_container",
-    embed = [":bb_copy_lib"],
-    pure = "on",
-    visibility = ["//visibility:public"],
+    images = [
+        ":image-arm64",
+        ":image-amd64",
+    ],
 )
 
 container_push_official(

--- a/cmd/bb_copy/BUILD.bazel
+++ b/cmd/bb_copy/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//tools:container.bzl", "container_push_official")
+load("//tools:container.bzl", "container_push_official", "multiarch_go_image")
 
 go_library(
     name = "bb_copy_lib",
@@ -21,43 +19,16 @@ go_library(
     ],
 )
 
-[
-    go_binary(
-        name = "bb_copy-{}".format(goarch),
-        embed = [":bb_copy_lib"],
-        pure = "on",
-        goarch = goarch,
-        goos = "linux",
-        visibility = ["//visibility:public"],
-    )
-    for goarch in ["amd64", "arm64"]
-]
+go_binary(
+    name = "bb_copy",
+    embed = [":bb_copy_lib"],
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
 
-[
-    pkg_tar(
-        name = "tar-{}".format(goarch),
-        srcs = ["bb_copy-{}".format(goarch)],
-        package_dir = "/app/cmd/bb_storage",
-    )
-    for goarch in ["amd64", "arm64"]
-]
-
-[
-    oci_image(
-        name = "image-{}".format(goarch),
-        base = "@distroless_static",
-        entrypoint = ["/app/cmd/bb_storage/bb_copy-{}".format(goarch)],
-        tars = ["tar-{}".format(goarch)],
-    )
-    for goarch in ["amd64", "arm64"]
-]
-
-oci_image_index(
+multiarch_go_image(
     name = "bb_copy_container",
-    images = [
-        ":image-arm64",
-        ":image-amd64",
-    ],
+    binary = ":bb_copy",
 )
 
 container_push_official(

--- a/cmd/bb_replicator/BUILD.bazel
+++ b/cmd/bb_replicator/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//tools:container.bzl", "container_push_official")
+load("//tools:container.bzl", "container_push_official", "multiarch_go_image")
 
 go_library(
     name = "bb_replicator_lib",
@@ -23,43 +21,16 @@ go_library(
     ],
 )
 
-[
-    go_binary(
-        name = "bb_replicator-{}".format(goarch),
-        embed = [":bb_replicator_lib"],
-        pure = "on",
-        goarch = goarch,
-        goos = "linux",
-        visibility = ["//visibility:public"],
-    )
-    for goarch in ["amd64", "arm64"]
-]
+go_binary(
+    name = "bb_replicator",
+    embed = [":bb_replicator_lib"],
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
 
-[
-    pkg_tar(
-        name = "tar-{}".format(goarch),
-        srcs = ["bb_replicator-{}".format(goarch)],
-        package_dir = "/app/cmd/bb_storage",
-    )
-    for goarch in ["amd64", "arm64"]
-]
-
-[
-    oci_image(
-        name = "image-{}".format(goarch),
-        base = "@distroless_static",
-        entrypoint = ["/app/cmd/bb_storage/bb_replicator-{}".format(goarch)],
-        tars = ["tar-{}".format(goarch)],
-    )
-    for goarch in ["amd64", "arm64"]
-]
-
-oci_image_index(
+multiarch_go_image(
     name = "bb_replicator_container",
-    images = [
-        ":image-arm64",
-        ":image-amd64",
-    ],
+    binary = ":bb_replicator",
 )
 
 container_push_official(

--- a/cmd/bb_replicator/BUILD.bazel
+++ b/cmd/bb_replicator/BUILD.bazel
@@ -1,6 +1,7 @@
-load("//tools:container.bzl", "container_push_official")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//tools:container.bzl", "container_push_official")
 
 go_library(
     name = "bb_replicator_lib",
@@ -22,18 +23,43 @@ go_library(
     ],
 )
 
-go_binary(
-    name = "bb_replicator",
-    embed = [":bb_replicator_lib"],
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
+[
+    go_binary(
+        name = "bb_replicator-{}".format(goarch),
+        embed = [":bb_replicator_lib"],
+        pure = "on",
+        goarch = goarch,
+        goos = "linux",
+        visibility = ["//visibility:public"],
+    )
+    for goarch in ["amd64", "arm64"]
+]
 
-go_image(
+[
+    pkg_tar(
+        name = "tar-{}".format(goarch),
+        srcs = ["bb_replicator-{}".format(goarch)],
+        package_dir = "/app/cmd/bb_storage",
+    )
+    for goarch in ["amd64", "arm64"]
+]
+
+[
+    oci_image(
+        name = "image-{}".format(goarch),
+        base = "@distroless_static",
+        entrypoint = ["/app/cmd/bb_storage/bb_replicator-{}".format(goarch)],
+        tars = ["tar-{}".format(goarch)],
+    )
+    for goarch in ["amd64", "arm64"]
+]
+
+oci_image_index(
     name = "bb_replicator_container",
-    embed = [":bb_replicator_lib"],
-    pure = "on",
-    visibility = ["//visibility:public"],
+    images = [
+        ":image-arm64",
+        ":image-amd64",
+    ],
 )
 
 container_push_official(

--- a/cmd/bb_storage/BUILD.bazel
+++ b/cmd/bb_storage/BUILD.bazel
@@ -1,7 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
-load("//tools:container.bzl", "container_push_official")
+load("//tools:container.bzl", "container_push_official", "multiarch_go_image")
 
 go_library(
     name = "bb_storage_lib",
@@ -31,43 +29,16 @@ go_library(
     ],
 )
 
-[
-    go_binary(
-        name = "bb_storage-{}".format(goarch),
-        embed = [":bb_storage_lib"],
-        pure = "on",
-        goarch = goarch,
-        goos = "linux",
-        visibility = ["//visibility:public"],
-    )
-    for goarch in ["amd64", "arm64"]
-]
+go_binary(
+    name = "bb_storage",
+    embed = [":bb_storage_lib"],
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
 
-[
-    pkg_tar(
-        name = "tar-{}".format(goarch),
-        srcs = ["bb_storage-{}".format(goarch)],
-        package_dir = "/app/cmd/bb_storage",
-    )
-    for goarch in ["amd64", "arm64"]
-]
-
-[
-    oci_image(
-        name = "image-{}".format(goarch),
-        base = "@distroless_static",
-        entrypoint = ["/app/cmd/bb_storage/bb_storage-{}".format(goarch)],
-        tars = ["tar-{}".format(goarch)],
-    )
-    for goarch in ["amd64", "arm64"]
-]
-
-oci_image_index(
+multiarch_go_image(
     name = "bb_storage_container",
-    images = [
-        ":image-arm64",
-        ":image-amd64",
-    ],
+    binary = ":bb_storage",
 )
 
 container_push_official(

--- a/cmd/bb_storage/BUILD.bazel
+++ b/cmd/bb_storage/BUILD.bazel
@@ -1,6 +1,7 @@
-load("//tools:container.bzl", "container_push_official")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("//tools:container.bzl", "container_push_official")
 
 go_library(
     name = "bb_storage_lib",
@@ -30,18 +31,43 @@ go_library(
     ],
 )
 
-go_binary(
-    name = "bb_storage",
-    embed = [":bb_storage_lib"],
-    pure = "on",
-    visibility = ["//visibility:public"],
-)
+[
+    go_binary(
+        name = "bb_storage-{}".format(goarch),
+        embed = [":bb_storage_lib"],
+        pure = "on",
+        goarch = goarch,
+        goos = "linux",
+        visibility = ["//visibility:public"],
+    )
+    for goarch in ["amd64", "arm64"]
+]
 
-go_image(
+[
+    pkg_tar(
+        name = "tar-{}".format(goarch),
+        srcs = ["bb_storage-{}".format(goarch)],
+        package_dir = "/app/cmd/bb_storage",
+    )
+    for goarch in ["amd64", "arm64"]
+]
+
+[
+    oci_image(
+        name = "image-{}".format(goarch),
+        base = "@distroless_static",
+        entrypoint = ["/app/cmd/bb_storage/bb_storage-{}".format(goarch)],
+        tars = ["tar-{}".format(goarch)],
+    )
+    for goarch in ["amd64", "arm64"]
+]
+
+oci_image_index(
     name = "bb_storage_container",
-    embed = [":bb_storage_lib"],
-    pure = "on",
-    visibility = ["//visibility:public"],
+    images = [
+        ":image-arm64",
+        ":image-amd64",
+    ],
 )
 
 container_push_official(

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
@@ -10,4 +11,15 @@ go_library(
         "@cc_mvdan_gofumpt//:gofumpt",
         "@org_golang_x_lint//:lint",
     ],
+)
+
+# When built with --stamp, creates a non-deterministic output file for pushing images to a remote registry.
+# With --nostamp, produces a deterministic output so dependents get cache hits.
+expand_template(
+    name = "stamped_tags",
+    out = "_stamped.tags.txt",
+    stamp_substitutions = {"_TAG_": "{BUILD_SCM_TIMESTAMP}-{BUILD_SCM_REVISION}"},
+    substitutions = {"_TAG_": "0.0.0"},
+    template = ["_TAG_"],
+    visibility = ["//visibility:public"],
 )

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -1,11 +1,9 @@
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+load("@rules_oci//oci:defs.bzl", "oci_push")
 
 def container_push_official(name, image, component):
-    container_push(
+    oci_push(
         name = name,
-        format = "Docker",
         image = image,
-        registry = "ghcr.io",
-        repository = "buildbarn/" + component,
-        tag = "{BUILD_SCM_TIMESTAMP}-{BUILD_SCM_REVISION}",
+        repository = "ghcr.io/buildbarn/" + component,
+        remote_tags = "//tools:stamped_tags",
     )

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -1,5 +1,5 @@
 load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
-load("@rules_oci//oci:defs.bzl", "oci_push", "oci_image", "oci_image_index")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index", "oci_push")
 load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 def multiarch_go_image(name, binary):

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -17,12 +17,13 @@ def multiarch_go_image(name, binary):
         name = tar_target,
         srcs = [binary],
         include_runfiles = True,
+        package_dir = "app",
     )
 
     oci_image(
         name = image_target,
         base = "@distroless_static",
-        entrypoint = ["/app/{}".format(binary)],
+        entrypoint = ["/app/{}".format(binary.removeprefix(":"))],
         tars = [tar_target],
     )
 

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -25,6 +25,9 @@ def multiarch_go_image(name, binary):
         base = "@distroless_static",
         entrypoint = ["/app/{}".format(native.package_relative_label(binary).name)],
         tars = [tar_target],
+        # Don't build un-transitioned images, as the default target architecture might be unsupported
+        # For example when building on linux-i386.
+        tags = ["manual"],
     )
 
     for arch in ["amd64", "arm64"]:

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -20,7 +20,7 @@ def multiarch_go_image(name, binary):
     )
     oci_image(
         name = image_target,
-        base = "@distroless_base",
+        base = "@distroless_static",
         entrypoint = ["/app/cmd/bb_storage/{}".format(binary)],
         tars = [tar_target],
     )

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -1,9 +1,48 @@
-load("@rules_oci//oci:defs.bzl", "oci_push")
+load("@aspect_bazel_lib//lib:transitions.bzl", "platform_transition_filegroup")
+load("@rules_oci//oci:defs.bzl", "oci_push", "oci_image", "oci_image_index")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+
+def multiarch_go_image(name, binary):
+    """Create a container image with two variants of the given go_binary target.
+    
+    Args:
+        name: resulting oci_image_index target
+        binary: label of a go_binary target; it may be transitioned to another architecture
+    """
+    images = []
+    tar_target = "_{}.tar".format(name)
+    image_target = "_{}.image".format(name)
+    pkg_tar(
+        name = tar_target,
+        srcs = [binary],
+        package_dir = "/app/cmd/bb_storage",
+        include_runfiles = True,
+    )
+    oci_image(
+        name = image_target,
+        base = "@distroless_base",
+        entrypoint = ["/app/cmd/bb_storage/{}".format(binary)],
+        tars = [tar_target],
+    )
+    for arch in ["amd64", "arm64"]:
+        arch_image_target = "{}_{}_image".format(name, arch)
+        target_platform = "@io_bazel_rules_go//go/toolchain:linux_{}".format(arch)
+        images.append(arch_image_target)
+        platform_transition_filegroup(
+            name = arch_image_target,
+            srcs = [image_target],
+            target_platform = target_platform,
+        )
+
+    oci_image_index(
+        name = name,
+        images = images,
+    )
 
 def container_push_official(name, image, component):
     oci_push(
         name = name,
         image = image,
         repository = "ghcr.io/buildbarn/" + component,
-        remote_tags = "//tools:stamped_tags",
+        remote_tags = "@com_github_buildbarn_bb_storage//tools:stamped_tags",
     )

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -4,7 +4,7 @@ load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 
 def multiarch_go_image(name, binary):
     """Create a container image with two variants of the given go_binary target.
-    
+
     Args:
         name: resulting oci_image_index target
         binary: label of a go_binary target; it may be transitioned to another architecture

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -23,7 +23,7 @@ def multiarch_go_image(name, binary):
     oci_image(
         name = image_target,
         base = "@distroless_static",
-        entrypoint = ["/app/{}".format(binary.removeprefix(":"))],
+        entrypoint = ["/app/{}".format(native.package_relative_label(binary).name)],
         tars = [tar_target],
     )
 

--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -12,18 +12,20 @@ def multiarch_go_image(name, binary):
     images = []
     tar_target = "_{}.tar".format(name)
     image_target = "_{}.image".format(name)
+
     pkg_tar(
         name = tar_target,
         srcs = [binary],
-        package_dir = "/app/cmd/bb_storage",
         include_runfiles = True,
     )
+
     oci_image(
         name = image_target,
         base = "@distroless_static",
-        entrypoint = ["/app/cmd/bb_storage/{}".format(binary)],
+        entrypoint = ["/app/{}".format(binary)],
         tars = [tar_target],
     )
+
     for arch in ["amd64", "arm64"]:
         arch_image_target = "{}_{}_image".format(name, arch)
         target_platform = "@io_bazel_rules_go//go/toolchain:linux_{}".format(arch)

--- a/tools/github_workflows/workflows_template.libsonnet
+++ b/tools/github_workflows/workflows_template.libsonnet
@@ -41,6 +41,7 @@
       buildAndTestCommand: 'build',
       // Building '//...' is broken for FreeBSD, because rules_docker
       // doesn't want to initialize properly.
+      // TODO(who?): now that rules_docker is removed, this could be revisited
       buildJustBinaries: true,
       extension: '',
     },


### PR DESCRIPTION
Allows bb-storage users to deploy on arm64 architecture, e.g. AWS Graviton. Fixes #198