### PR TITLE
fix: release stamping needs double curlies

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -18,7 +18,7 @@ go_library(
 expand_template(
     name = "stamped_tags",
     out = "_stamped.tags.txt",
-    stamp_substitutions = {"_TAG_": "{BUILD_SCM_TIMESTAMP}-{BUILD_SCM_REVISION}"},
+    stamp_substitutions = {"_TAG_": "{{BUILD_SCM_TIMESTAMP}}-{{BUILD_SCM_REVISION}}"},
     substitutions = {"_TAG_": "0.0.0"},
     template = ["_TAG_"],
     visibility = ["//visibility:public"],


### PR DESCRIPTION
Fixes broken release step on master https://github.com/buildbarn/bb-storage/actions/runs/8426759325/job/23075783496
broken by #199 

Example of use showing correct interpolation: https://github.com/aspect-build/bazel-lib/blob/0fc838839c41677b18245152ad50759233c53794/lib/tests/expand_template/BUILD.bazel#L11

And if you're curious, the code is here: https://github.com/aspect-build/bazel-lib/blob/0fc838839c41677b18245152ad50759233c53794/tools/expand_template/main.go#L48