### PR TITLE
Open directories using O_SEARCH

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -100,6 +100,10 @@ go_deps_dev.module_override(
     path = "golang.org/x/oauth2",
 )
 go_deps_dev.module_override(
+    patches = ["//:patches/org_golang_x_sys/o-search.diff"],
+    path = "golang.org/x/sys",
+)
+go_deps_dev.module_override(
     patches = ["//:patches/org_uber_go_mock/mocks-for-funcs.diff"],
     path = "go.uber.org/mock",
 )

--- a/patches/org_golang_x_sys/o-search.diff
+++ b/patches/org_golang_x_sys/o-search.diff
@@ -1,0 +1,40 @@
+diff --git unix/zerrors_darwin_amd64.go unix/zerrors_darwin_amd64.go
+index d73c465..d406964 100644
+--- unix/zerrors_darwin_amd64.go
++++ unix/zerrors_darwin_amd64.go
+@@ -1128,6 +1128,7 @@ const (
+ 	O_DSYNC                                 = 0x400000
+ 	O_EVTONLY                               = 0x8000
+ 	O_EXCL                                  = 0x800
++	O_EXEC                                  = 0x40000000
+ 	O_EXLOCK                                = 0x20
+ 	O_FSYNC                                 = 0x80
+ 	O_NDELAY                                = 0x4
+@@ -1138,6 +1139,7 @@ const (
+ 	O_POPUP                                 = 0x80000000
+ 	O_RDONLY                                = 0x0
+ 	O_RDWR                                  = 0x2
++	O_SEARCH                                = 0x40100000
+ 	O_SHLOCK                                = 0x10
+ 	O_SYMLINK                               = 0x200000
+ 	O_SYNC                                  = 0x80
+diff --git unix/zerrors_darwin_arm64.go unix/zerrors_darwin_arm64.go
+index 4a55a40..c47c6e9 100644
+--- unix/zerrors_darwin_arm64.go
++++ unix/zerrors_darwin_arm64.go
+@@ -1128,6 +1128,7 @@ const (
+ 	O_DSYNC                                 = 0x400000
+ 	O_EVTONLY                               = 0x8000
+ 	O_EXCL                                  = 0x800
++	O_EXEC                                  = 0x40000000
+ 	O_EXLOCK                                = 0x20
+ 	O_FSYNC                                 = 0x80
+ 	O_NDELAY                                = 0x4
+@@ -1138,6 +1139,7 @@ const (
+ 	O_POPUP                                 = 0x80000000
+ 	O_RDONLY                                = 0x0
+ 	O_RDWR                                  = 0x2
++	O_SEARCH                                = 0x40100000
+ 	O_SHLOCK                                = 0x10
+ 	O_SYMLINK                               = 0x200000
+ 	O_SYNC                                  = 0x80

--- a/pkg/filesystem/local_directory_darwin.go
+++ b/pkg/filesystem/local_directory_darwin.go
@@ -16,6 +16,8 @@ import (
 // rawDeviceNumber is the equivalent of POSIX dev_t.
 type rawDeviceNumber = int32
 
+const oflagSearch = unix.O_SEARCH
+
 func (d *localDirectory) Mknod(name path.Component, perm os.FileMode, deviceNumber DeviceNumber) error {
 	return status.Error(codes.Unimplemented, "Creation of device nodes is not supported on Darwin")
 }

--- a/pkg/filesystem/local_directory_freebsd.go
+++ b/pkg/filesystem/local_directory_freebsd.go
@@ -8,12 +8,15 @@ import (
 
 	"github.com/buildbarn/bb-storage/pkg/filesystem/path"
 
+	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
 
 // rawDeviceNumber is the equivalent of POSIX dev_t.
 type rawDeviceNumber = uint64
+
+const oflagSearch = unix.O_SEARCH
 
 func (d *localDirectory) Mknod(name path.Component, perm os.FileMode, deviceNumber DeviceNumber) error {
 	// Though mknodat() exists on FreeBSD, device nodes created

--- a/pkg/filesystem/local_directory_linux.go
+++ b/pkg/filesystem/local_directory_linux.go
@@ -18,6 +18,8 @@ import (
 // rawDeviceNumber is the equivalent of POSIX dev_t.
 type rawDeviceNumber = uint64
 
+const oflagSearch = unix.O_PATH
+
 func (d *localDirectory) Mknod(name path.Component, perm os.FileMode, deviceNumber DeviceNumber) error {
 	defer runtime.KeepAlive(d)
 


### PR DESCRIPTION
Right now we open directories using O_RDONLY. This is problematic, because it means we can't perform operations on directories that only have execute permissions. The solution for this is to use O_SEARCH, which was added in POSIX 2008.

Linux doesn't offer O_SEARCH, but we can emulate it using O_PATH. macOS has supported this feature since Ventura (October 2022).