### PR TITLE
add missing label on replicator metrics and unit test

### DIFF
--- a/pkg/blobstore/replication/BUILD.bazel
+++ b/pkg/blobstore/replication/BUILD.bazel
@@ -45,8 +45,8 @@ go_test(
         "nested_blob_replicator_test.go",
         "queued_blob_replicator_test.go",
     ],
-    embed = [":replication"],
     deps = [
+        ":replication",
         "//internal/mock",
         "//pkg/blobstore/buffer",
         "//pkg/digest",

--- a/pkg/blobstore/replication/BUILD.bazel
+++ b/pkg/blobstore/replication/BUILD.bazel
@@ -41,6 +41,7 @@ go_test(
     srcs = [
         "deduplicating_blob_replicator_test.go",
         "local_blob_replicator_test.go",
+        "metrics_blob_replicator_test.go",
         "nested_blob_replicator_test.go",
         "queued_blob_replicator_test.go",
     ],
@@ -48,6 +49,7 @@ go_test(
         ":replication",
         "//internal/mock",
         "//pkg/blobstore/buffer",
+        "//pkg/clock",
         "//pkg/digest",
         "//pkg/eviction",
         "//pkg/testutil",

--- a/pkg/blobstore/replication/BUILD.bazel
+++ b/pkg/blobstore/replication/BUILD.bazel
@@ -45,11 +45,10 @@ go_test(
         "nested_blob_replicator_test.go",
         "queued_blob_replicator_test.go",
     ],
+    embed = [":replication"],
     deps = [
-        ":replication",
         "//internal/mock",
         "//pkg/blobstore/buffer",
-        "//pkg/clock",
         "//pkg/digest",
         "//pkg/eviction",
         "//pkg/testutil",

--- a/pkg/blobstore/replication/metrics_blob_replicator.go
+++ b/pkg/blobstore/replication/metrics_blob_replicator.go
@@ -27,7 +27,7 @@ var (
 			Help:      "Amount of time spent per operation on blob replicator, in seconds.",
 			Buckets:   util.DecimalExponentialBuckets(-3, 6, 2),
 		},
-		[]string{"operation"})
+		[]string{"storage_type", "operation"})
 
 	blobReplicatorOperationsBlobSizeBytes = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -37,7 +37,7 @@ var (
 			Help:      "Size of blobs being replicated, in bytes.",
 			Buckets:   prometheus.ExponentialBuckets(1.0, 2.0, 33),
 		},
-		[]string{"operation"})
+		[]string{"storage_type", "operation"})
 
 	blobReplicatorOperationsBatchSize = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
@@ -47,7 +47,7 @@ var (
 			Help:      "Number of blobs in batch replication requests.",
 			Buckets:   prometheus.ExponentialBuckets(1.0, 2.0, 17),
 		},
-		[]string{"operation"})
+		[]string{"storage_type", "operation"})
 )
 
 type metricsBlobReplicator struct {
@@ -78,21 +78,21 @@ func NewMetricsBlobReplicator(replicator BlobReplicator, clock clock.Clock, stor
 		replicator: replicator,
 		clock:      clock,
 		singleDurationSeconds: blobReplicatorOperationsDurationSeconds.MustCurryWith(map[string]string{
-			"operation": "ReplicateSingle",
-			"storage":   storageTypeName,
+			"storage_type": storageTypeName,
+			"operation":    "ReplicateSingle",
 		}),
-		singleBlobSizeBytes: blobReplicatorOperationsBlobSizeBytes.WithLabelValues("ReplicateSingle", storageTypeName),
+		singleBlobSizeBytes: blobReplicatorOperationsBlobSizeBytes.WithLabelValues(storageTypeName, "ReplicateSingle"),
 		compositeDurationSeconds: blobReplicatorOperationsDurationSeconds.MustCurryWith(map[string]string{
-			"operation": "ReplicateComposite",
-			"storage":   storageTypeName,
+			"storage_type": storageTypeName,
+			"operation":    "ReplicateComposite",
 		}),
-		compositeBlobSizeBytes: blobReplicatorOperationsBlobSizeBytes.WithLabelValues("ReplicateComposite", storageTypeName),
+		compositeBlobSizeBytes: blobReplicatorOperationsBlobSizeBytes.WithLabelValues(storageTypeName, "ReplicateComposite"),
 		multipleDurationSeconds: blobReplicatorOperationsDurationSeconds.MustCurryWith(map[string]string{
-			"operation": "ReplicateMultiple",
-			"storage":   storageTypeName,
+			"storage_type": storageTypeName,
+			"operation":    "ReplicateMultiple",
 		}),
-		multipleBlobSizeBytes: blobReplicatorOperationsBlobSizeBytes.WithLabelValues("ReplicateMultiple", storageTypeName),
-		multipleBatchSize:     blobReplicatorOperationsBatchSize.WithLabelValues("ReplicateMultiple", storageTypeName),
+		multipleBlobSizeBytes: blobReplicatorOperationsBlobSizeBytes.WithLabelValues(storageTypeName, "ReplicateMultiple"),
+		multipleBatchSize:     blobReplicatorOperationsBatchSize.WithLabelValues(storageTypeName, "ReplicateMultiple"),
 	}
 }
 

--- a/pkg/blobstore/replication/metrics_blob_replicator_test.go
+++ b/pkg/blobstore/replication/metrics_blob_replicator_test.go
@@ -1,4 +1,4 @@
-package replication
+package replication_test
 
 import (
 	"testing"

--- a/pkg/blobstore/replication/metrics_blob_replicator_test.go
+++ b/pkg/blobstore/replication/metrics_blob_replicator_test.go
@@ -1,0 +1,24 @@
+package replication
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/buildbarn/bb-storage/internal/mock"
+	"github.com/buildbarn/bb-storage/pkg/blobstore/replication"
+	"go.uber.org/mock/gomock"
+)
+
+func TestNewMetricsBlobReplicator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	// Create mock using the generated mock
+	mockReplicator := mock.NewMockBlobReplicator(ctrl)
+	mockClock := mock.NewMockClock(ctrl)
+
+	// Create a new MetricsBlobReplicator
+	storageTypeName := "cas"
+	metricsReplicator := replication.NewMetricsBlobReplicator(mockReplicator, mockClock, storageTypeName)
+	require.NotNil(t, metricsReplicator)
+}

--- a/pkg/blobstore/replication/metrics_blob_replicator_test.go
+++ b/pkg/blobstore/replication/metrics_blob_replicator_test.go
@@ -1,8 +1,9 @@
 package replication
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/buildbarn/bb-storage/internal/mock"
 	"github.com/buildbarn/bb-storage/pkg/blobstore/replication"


### PR DESCRIPTION
The storage type label is missing from metrics blob replicator, causing the initialization to fail on: 
panic: 1 unknown label(s) found during currying

goroutine 1 [running]:
github.com/prometheus/client_golang/prometheus.(*HistogramVec).MustCurryWith(...)
	external/gazelle~~go_deps~com_github_prometheus_client_golang/prometheus/histogram.go:1278

Also, add a unit test to catch this case. 