### PR TITLE
chore: update distroless/static to latest

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -135,7 +135,7 @@ use_repo(npm, "com_github_buildbarn_bb_storage_npm")
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
     name = "distroless_static",
-    digest = "sha256:7e5c6a2a4ae854242874d36171b31d26e0539c98fc6080f942f16b03e82851ab",
+    digest = "sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac",
     image = "gcr.io/distroless/static",
     platforms = [
         "linux/amd64",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -1578,7 +1578,7 @@
     "@@rules_oci~//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "QQaVAJS6SkVdVrwKXxsPURoBcc5B6gTself8OwWFRIg=",
-        "usagesDigest": "Si+ldrLlvEYW6xVFNQHU+oWNkHX+B5zwVN7cTU1lkyQ=",
+        "usagesDigest": "BPBnTVajVNU6RJROnOMEEp4GK3nWzTtac+0WaKK7tQU=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -1733,7 +1733,7 @@
               "scheme": "https",
               "registry": "gcr.io",
               "repository": "distroless/static",
-              "identifier": "sha256:7e5c6a2a4ae854242874d36171b31d26e0539c98fc6080f942f16b03e82851ab",
+              "identifier": "sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@distroless_static_linux_amd64",
                 "@@platforms//cpu:arm64": "@distroless_static_linux_arm64_v8"
@@ -1749,7 +1749,7 @@
               "scheme": "https",
               "registry": "gcr.io",
               "repository": "distroless/static",
-              "identifier": "sha256:7e5c6a2a4ae854242874d36171b31d26e0539c98fc6080f942f16b03e82851ab",
+              "identifier": "sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac",
               "platform": "linux/amd64",
               "target_name": "distroless_static_linux_amd64",
               "bazel_tags": []
@@ -1947,7 +1947,7 @@
               "scheme": "https",
               "registry": "gcr.io",
               "repository": "distroless/static",
-              "identifier": "sha256:7e5c6a2a4ae854242874d36171b31d26e0539c98fc6080f942f16b03e82851ab",
+              "identifier": "sha256:3f2b64ef97bd285e36132c684e6b2ae8f2723293d09aae046196cca64251acac",
               "platform": "linux/arm64/v8",
               "target_name": "distroless_static_linux_arm64_v8",
               "bazel_tags": []


### PR DESCRIPTION
Updates distroless/static to latest to pull in tzdata security update described here: https://lwn.net/Articles/1000160/