### PR TITLE
Return 401 for XHR requests when not authenticated with OIDC

### DIFF
--- a/pkg/http/oidc_authenticator.go
+++ b/pkg/http/oidc_authenticator.go
@@ -254,7 +254,14 @@ func (a *oidcAuthenticator) Authenticate(w http.ResponseWriter, r *http.Request)
 		}
 	}
 
-	// No valid session present. Redirect to the authorization service.
+	// No valid session present. Redirect to the authorization service if this
+	// is a top level page navigation (or unknown). Otherwise, return a 401
+	// Unauthorized.
+
+	if fetchType := r.Header.Get("Sec-Fetch-Dest"); fetchType != "" && fetchType != "document" {
+		return nil, status.Error(codes.Unauthenticated, "No valid OIDC session state cookie found")
+	}
+
 	var stateVerifier [16]byte
 	if _, err := a.randomNumberGenerator.Read(stateVerifier[:]); err != nil {
 		return nil, err


### PR DESCRIPTION
Instead of returning a 303 (See Other) with a redirect to the OIDC login page, we return a 401 (Unauthorized) to the XHR request. This makes it easier for a web client to handle authentication errors.