### PR TITLE
Add a generic util.Must function

### DIFF
--- a/pkg/auth/BUILD.bazel
+++ b/pkg/auth/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//pkg/eviction",
         "//pkg/proto/auth",
         "//pkg/testutil",
+        "//pkg/util",
         "@com_github_jmespath_go_jmespath//:go-jmespath",
         "@com_github_stretchr_testify//require",
         "@io_opentelemetry_go_otel//attribute",

--- a/pkg/auth/any_authorizer_test.go
+++ b/pkg/auth/any_authorizer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -21,8 +22,8 @@ func TestAnyAuthorizerZero(t *testing.T) {
 	authorizer := auth.NewAnyAuthorizer(nil)
 
 	errs := authorizer.Authorize(context.Background(), []digest.InstanceName{
-		digest.MustNewInstanceName("hello"),
-		digest.MustNewInstanceName("world"),
+		util.Must(digest.NewInstanceName("hello")),
+		util.Must(digest.NewInstanceName("world")),
 	})
 	require.Len(t, errs, 2)
 	testutil.RequireEqualStatus(t, status.Error(codes.PermissionDenied, "Permission denied"), errs[0])
@@ -37,9 +38,9 @@ func TestAnyAuthorizerOne(t *testing.T) {
 	authorizer := auth.NewAnyAuthorizer([]auth.Authorizer{baseAuthorizer})
 
 	baseAuthorizer.EXPECT().Authorize(ctx, []digest.InstanceName{
-		digest.MustNewInstanceName("ok"),
-		digest.MustNewInstanceName("denied"),
-		digest.MustNewInstanceName("unavailable"),
+		util.Must(digest.NewInstanceName("ok")),
+		util.Must(digest.NewInstanceName("denied")),
+		util.Must(digest.NewInstanceName("unavailable")),
 	}).Return([]error{
 		nil,
 		status.Error(codes.PermissionDenied, "Permission denied"),
@@ -47,9 +48,9 @@ func TestAnyAuthorizerOne(t *testing.T) {
 	})
 
 	errs := authorizer.Authorize(ctx, []digest.InstanceName{
-		digest.MustNewInstanceName("ok"),
-		digest.MustNewInstanceName("denied"),
-		digest.MustNewInstanceName("unavailable"),
+		util.Must(digest.NewInstanceName("ok")),
+		util.Must(digest.NewInstanceName("denied")),
+		util.Must(digest.NewInstanceName("unavailable")),
 	})
 	require.Len(t, errs, 3)
 	require.NoError(t, errs[0])
@@ -71,13 +72,13 @@ func TestAnyAuthorizerMultiple(t *testing.T) {
 	})
 
 	baseAuthorizer1.EXPECT().Authorize(ctx, []digest.InstanceName{
-		digest.MustNewInstanceName("ok1"),
-		digest.MustNewInstanceName("ok2"),
-		digest.MustNewInstanceName("ok3"),
-		digest.MustNewInstanceName("denied"),
-		digest.MustNewInstanceName("unavailable1"),
-		digest.MustNewInstanceName("unavailable2"),
-		digest.MustNewInstanceName("unavailable3"),
+		util.Must(digest.NewInstanceName("ok1")),
+		util.Must(digest.NewInstanceName("ok2")),
+		util.Must(digest.NewInstanceName("ok3")),
+		util.Must(digest.NewInstanceName("denied")),
+		util.Must(digest.NewInstanceName("unavailable1")),
+		util.Must(digest.NewInstanceName("unavailable2")),
+		util.Must(digest.NewInstanceName("unavailable3")),
 	}).Return([]error{
 		nil,
 		status.Error(codes.PermissionDenied, "1: Permission denied for ok2"),
@@ -88,11 +89,11 @@ func TestAnyAuthorizerMultiple(t *testing.T) {
 		status.Error(codes.PermissionDenied, "1: Permission denied for unavailable3"),
 	})
 	baseAuthorizer2.EXPECT().Authorize(ctx, []digest.InstanceName{
-		digest.MustNewInstanceName("ok2"),
-		digest.MustNewInstanceName("ok3"),
-		digest.MustNewInstanceName("denied"),
-		digest.MustNewInstanceName("unavailable2"),
-		digest.MustNewInstanceName("unavailable3"),
+		util.Must(digest.NewInstanceName("ok2")),
+		util.Must(digest.NewInstanceName("ok3")),
+		util.Must(digest.NewInstanceName("denied")),
+		util.Must(digest.NewInstanceName("unavailable2")),
+		util.Must(digest.NewInstanceName("unavailable3")),
 	}).Return([]error{
 		nil,
 		status.Error(codes.PermissionDenied, "2: Permission denied for ok3"),
@@ -101,9 +102,9 @@ func TestAnyAuthorizerMultiple(t *testing.T) {
 		status.Error(codes.PermissionDenied, "2: Permission denied for unavailable3"),
 	})
 	baseAuthorizer3.EXPECT().Authorize(ctx, []digest.InstanceName{
-		digest.MustNewInstanceName("ok3"),
-		digest.MustNewInstanceName("denied"),
-		digest.MustNewInstanceName("unavailable3"),
+		util.Must(digest.NewInstanceName("ok3")),
+		util.Must(digest.NewInstanceName("denied")),
+		util.Must(digest.NewInstanceName("unavailable3")),
 	}).Return([]error{
 		nil,
 		status.Error(codes.PermissionDenied, "3: Permission denied for denied"),
@@ -111,13 +112,13 @@ func TestAnyAuthorizerMultiple(t *testing.T) {
 	})
 
 	errs := authorizer.Authorize(ctx, []digest.InstanceName{
-		digest.MustNewInstanceName("ok1"),
-		digest.MustNewInstanceName("ok2"),
-		digest.MustNewInstanceName("ok3"),
-		digest.MustNewInstanceName("denied"),
-		digest.MustNewInstanceName("unavailable1"),
-		digest.MustNewInstanceName("unavailable2"),
-		digest.MustNewInstanceName("unavailable3"),
+		util.Must(digest.NewInstanceName("ok1")),
+		util.Must(digest.NewInstanceName("ok2")),
+		util.Must(digest.NewInstanceName("ok3")),
+		util.Must(digest.NewInstanceName("denied")),
+		util.Must(digest.NewInstanceName("unavailable1")),
+		util.Must(digest.NewInstanceName("unavailable2")),
+		util.Must(digest.NewInstanceName("unavailable3")),
 	})
 	require.Len(t, errs, 7)
 	require.NoError(t, errs[0])

--- a/pkg/auth/authentication_metadata.go
+++ b/pkg/auth/authentication_metadata.go
@@ -68,17 +68,6 @@ func NewAuthenticationMetadataFromRaw(metadataRaw any) (*AuthenticationMetadata,
 	return NewAuthenticationMetadataFromProto(&metadataMessage)
 }
 
-// MustNewAuthenticationMetadataFromProto is identical to
-// NewAuthenticationMetadataFromProto(), except that it panics upon failure. This
-// method is provided for testing.
-func MustNewAuthenticationMetadataFromProto(message *auth_pb.AuthenticationMetadata) *AuthenticationMetadata {
-	authenticationMetadata, err := NewAuthenticationMetadataFromProto(message)
-	if err != nil {
-		panic(err)
-	}
-	return authenticationMetadata
-}
-
 // GetRaw returns the original JSON-like value that was used to
 // construct the AuthenticationMetadata.
 func (am *AuthenticationMetadata) GetRaw() map[string]any {

--- a/pkg/auth/static_authorizer_test.go
+++ b/pkg/auth/static_authorizer_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -18,21 +19,21 @@ func TestStaticAuthorizer(t *testing.T) {
 	matcher := func(in digest.InstanceName) bool { return strings.Contains(in.String(), "allowed") }
 	a := auth.NewStaticAuthorizer(matcher)
 
-	errs := a.Authorize(context.Background(), []digest.InstanceName{digest.MustNewInstanceName("allowed")})
+	errs := a.Authorize(context.Background(), []digest.InstanceName{util.Must(digest.NewInstanceName("allowed"))})
 	require.NoError(t, errs[0])
 
-	errs = a.Authorize(context.Background(), []digest.InstanceName{digest.MustNewInstanceName("allowed"), digest.MustNewInstanceName("other-allowed")})
+	errs = a.Authorize(context.Background(), []digest.InstanceName{util.Must(digest.NewInstanceName("allowed")), util.Must(digest.NewInstanceName("other-allowed"))})
 	require.NoError(t, errs[0])
 	require.NoError(t, errs[1])
 
-	errs = a.Authorize(context.Background(), []digest.InstanceName{digest.MustNewInstanceName("forbidden")})
+	errs = a.Authorize(context.Background(), []digest.InstanceName{util.Must(digest.NewInstanceName("forbidden"))})
 	testutil.RequireEqualStatus(t, status.Error(codes.PermissionDenied, "Permission denied"), errs[0])
 
-	errs = a.Authorize(context.Background(), []digest.InstanceName{digest.MustNewInstanceName("allowed"), digest.MustNewInstanceName("forbidden")})
+	errs = a.Authorize(context.Background(), []digest.InstanceName{util.Must(digest.NewInstanceName("allowed")), util.Must(digest.NewInstanceName("forbidden"))})
 	require.NoError(t, errs[0])
 	testutil.RequireEqualStatus(t, status.Error(codes.PermissionDenied, "Permission denied"), errs[1])
 
-	errs = a.Authorize(context.Background(), []digest.InstanceName{digest.MustNewInstanceName("forbidden"), digest.MustNewInstanceName("allowed")})
+	errs = a.Authorize(context.Background(), []digest.InstanceName{util.Must(digest.NewInstanceName("forbidden")), util.Must(digest.NewInstanceName("allowed"))})
 	testutil.RequireEqualStatus(t, status.Error(codes.PermissionDenied, "Permission denied"), errs[0])
 	require.NoError(t, errs[1])
 }

--- a/pkg/blobstore/BUILD.bazel
+++ b/pkg/blobstore/BUILD.bazel
@@ -81,6 +81,7 @@ go_test(
         "//pkg/eviction",
         "//pkg/proto/icas",
         "//pkg/testutil",
+        "//pkg/util",
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@com_github_aws_aws_sdk_go_v2//aws",
         "@com_github_aws_aws_sdk_go_v2_service_s3//:s3",

--- a/pkg/blobstore/authorizing_blob_access_test.go
+++ b/pkg/blobstore/authorizing_blob_access_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"go.uber.org/mock/gomock"
@@ -32,9 +33,9 @@ func TestAuthorizingBlobAccess(t *testing.T) {
 	wantBytes := []byte("European Burmese")
 	wantBuf := buffer.NewValidatedBufferFromByteSlice(wantBytes)
 
-	beep := digest.MustNewInstanceName("beep")
+	beep := util.Must(digest.NewInstanceName("beep"))
 	beepSlice := []digest.InstanceName{beep}
-	bopBip := digest.MustNewInstanceName("bop/bip")
+	bopBip := util.Must(digest.NewInstanceName("bop/bip"))
 	beepBopBipSlice := []digest.InstanceName{beep, bopBip}
 
 	t.Run("Get-Allowed", func(t *testing.T) {

--- a/pkg/blobstore/demultiplexing_blob_access_test.go
+++ b/pkg/blobstore/demultiplexing_blob_access_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -26,7 +27,7 @@ func TestDemultiplexingBlobAccessGet(t *testing.T) {
 
 	t.Run("UnknownInstanceName", func(t *testing.T) {
 		// This request cannot be forwarded to any backend.
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("unknown")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("unknown"))).Return(
 			nil,
 			"",
 			digest.NoopInstanceNamePatcher,
@@ -42,12 +43,12 @@ func TestDemultiplexingBlobAccessGet(t *testing.T) {
 	t.Run("BackendFailure", func(t *testing.T) {
 		// Error messages should have the backend name prepended.
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
 		baseBlobAccess.EXPECT().Get(ctx, digest.MustNewDigest("goodbye/world", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 			Return(buffer.NewBufferFromError(status.Error(codes.Internal, "Server on fire")))
@@ -61,12 +62,12 @@ func TestDemultiplexingBlobAccessGet(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
 		baseBlobAccess.EXPECT().Get(ctx, digest.MustNewDigest("goodbye/world", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 			Return(buffer.NewValidatedBufferFromByteSlice([]byte("Hello")))
@@ -88,7 +89,7 @@ func TestDemultiplexingBlobAccessGetFromComposite(t *testing.T) {
 
 	t.Run("UnknownInstanceName", func(t *testing.T) {
 		// This request cannot be forwarded to any backend.
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("unknown")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("unknown"))).Return(
 			nil,
 			"",
 			digest.NoopInstanceNamePatcher,
@@ -107,12 +108,12 @@ func TestDemultiplexingBlobAccessGetFromComposite(t *testing.T) {
 	t.Run("BackendFailure", func(t *testing.T) {
 		// Error messages should have the backend name prepended.
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
 		blobSlicer := mock.NewMockBlobSlicer(ctrl)
 		baseBlobAccess.EXPECT().GetFromComposite(
@@ -133,12 +134,12 @@ func TestDemultiplexingBlobAccessGetFromComposite(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
 		blobSlicer := mock.NewMockBlobSlicer(ctrl)
 		baseBlobAccess.EXPECT().GetFromComposite(
@@ -167,7 +168,7 @@ func TestDemultiplexingBlobAccessPut(t *testing.T) {
 
 	t.Run("UnknownInstanceName", func(t *testing.T) {
 		// This request cannot be forwarded to any backend.
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("unknown")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("unknown"))).Return(
 			nil,
 			"",
 			digest.NoopInstanceNamePatcher,
@@ -185,12 +186,12 @@ func TestDemultiplexingBlobAccessPut(t *testing.T) {
 	t.Run("BackendFailure", func(t *testing.T) {
 		// Error messages should have the backend name prepended.
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
 		baseBlobAccess.EXPECT().Put(ctx, digest.MustNewDigest("goodbye/world", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, digest digest.Digest, b buffer.Buffer) error {
@@ -209,12 +210,12 @@ func TestDemultiplexingBlobAccessPut(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
 		baseBlobAccess.EXPECT().Put(ctx, digest.MustNewDigest("goodbye/world", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5), gomock.Any()).
 			DoAndReturn(func(ctx context.Context, digest digest.Digest, b buffer.Buffer) error {
@@ -241,7 +242,7 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 
 	t.Run("UnknownInstanceName", func(t *testing.T) {
 		// This request cannot be forwarded to any backend.
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("unknown")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("unknown"))).Return(
 			nil,
 			"",
 			digest.NoopInstanceNamePatcher,
@@ -256,12 +257,12 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 	t.Run("BackendFailure", func(t *testing.T) {
 		// Error messages should have the backend name prepended.
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
 		baseBlobAccess.EXPECT().FindMissing(
 			ctx,
@@ -287,34 +288,34 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 		// against the backends. Report half of the digests as
 		// missing.
 		baseBlobAccessA := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("a")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("a"))).Return(
 			baseBlobAccessA,
 			"a",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("a"),
-				digest.MustNewInstanceName("A")),
+				util.Must(digest.NewInstanceName("a")),
+				util.Must(digest.NewInstanceName("A"))),
 			nil)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("a/x")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("a/x"))).Return(
 			baseBlobAccessA,
 			"a",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("a"),
-				digest.MustNewInstanceName("A")),
+				util.Must(digest.NewInstanceName("a")),
+				util.Must(digest.NewInstanceName("A"))),
 			nil)
 		baseBlobAccessB := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("b")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("b"))).Return(
 			baseBlobAccessB,
 			"b",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("b"),
-				digest.MustNewInstanceName("B")),
+				util.Must(digest.NewInstanceName("b")),
+				util.Must(digest.NewInstanceName("B"))),
 			nil)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("b/x")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("b/x"))).Return(
 			baseBlobAccessB,
 			"b",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("b"),
-				digest.MustNewInstanceName("B")),
+				util.Must(digest.NewInstanceName("b")),
+				util.Must(digest.NewInstanceName("B"))),
 			nil)
 		baseBlobAccessA.EXPECT().FindMissing(
 			ctx,
@@ -378,43 +379,43 @@ func TestDemultiplexingBlobAccessGetCapabilities(t *testing.T) {
 
 	t.Run("UnknownInstanceName", func(t *testing.T) {
 		// This request cannot be forwarded to any backend.
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("unknown")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("unknown"))).Return(
 			nil,
 			"",
 			digest.NoopInstanceNamePatcher,
 			status.Error(codes.InvalidArgument, "Unknown instance name"))
 
-		_, err := blobAccess.GetCapabilities(ctx, digest.MustNewInstanceName("unknown"))
+		_, err := blobAccess.GetCapabilities(ctx, util.Must(digest.NewInstanceName("unknown")))
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Unknown instance name"), err)
 	})
 
 	t.Run("BackendFailure", func(t *testing.T) {
 		// Error messages should have the backend name prepended.
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
-		baseBlobAccess.EXPECT().GetCapabilities(ctx, digest.MustNewInstanceName("goodbye/world")).
+		baseBlobAccess.EXPECT().GetCapabilities(ctx, util.Must(digest.NewInstanceName("goodbye/world"))).
 			Return(nil, status.Error(codes.Internal, "Server offline"))
 
-		_, err := blobAccess.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		_, err := blobAccess.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		testutil.RequireEqualStatus(t, status.Error(codes.Internal, "Backend \"Primary\": Server offline"), err)
 	})
 
 	t.Run("Success", func(t *testing.T) {
 		baseBlobAccess := mock.NewMockBlobAccess(ctrl)
-		demultiplexedBlobAccessGetter.EXPECT().Call(digest.MustNewInstanceName("hello/world")).Return(
+		demultiplexedBlobAccessGetter.EXPECT().Call(util.Must(digest.NewInstanceName("hello/world"))).Return(
 			baseBlobAccess,
 			"Primary",
 			digest.NewInstanceNamePatcher(
-				digest.MustNewInstanceName("hello"),
-				digest.MustNewInstanceName("goodbye")),
+				util.Must(digest.NewInstanceName("hello")),
+				util.Must(digest.NewInstanceName("goodbye"))),
 			nil)
-		baseBlobAccess.EXPECT().GetCapabilities(ctx, digest.MustNewInstanceName("goodbye/world")).
+		baseBlobAccess.EXPECT().GetCapabilities(ctx, util.Must(digest.NewInstanceName("goodbye/world"))).
 			Return(&remoteexecution.ServerCapabilities{
 				CacheCapabilities: &remoteexecution.CacheCapabilities{
 					ActionCacheUpdateCapabilities: &remoteexecution.ActionCacheUpdateCapabilities{
@@ -423,7 +424,7 @@ func TestDemultiplexingBlobAccessGetCapabilities(t *testing.T) {
 				},
 			}, nil)
 
-		serverCapabilities, err := blobAccess.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		serverCapabilities, err := blobAccess.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		require.NoError(t, err)
 		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
 			CacheCapabilities: &remoteexecution.CacheCapabilities{

--- a/pkg/blobstore/grpcclients/BUILD.bazel
+++ b/pkg/blobstore/grpcclients/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/blobstore/buffer",
         "//pkg/digest",
         "//pkg/testutil",
+        "//pkg/util",
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@bazel_remote_apis//build/bazel/semver:semver_go_proto",
         "@com_github_google_uuid//:uuid",

--- a/pkg/blobstore/grpcclients/cas_blob_access_test.go
+++ b/pkg/blobstore/grpcclients/cas_blob_access_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/blobstore/grpcclients"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -180,7 +181,7 @@ func TestCASBlobAccessGetCapabilities(t *testing.T) {
 			gomock.Any(),
 		).Return(status.Error(codes.Unavailable, "Server offline"))
 
-		_, err := blobAccess.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		_, err := blobAccess.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		testutil.RequireEqualStatus(t, status.Error(codes.Unavailable, "Server offline"), err)
 	})
 
@@ -206,7 +207,7 @@ func TestCASBlobAccessGetCapabilities(t *testing.T) {
 			return nil
 		})
 
-		_, err := blobAccess.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		_, err := blobAccess.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Instance name \"hello/world\" does not support remote caching"), err)
 	})
 
@@ -246,7 +247,7 @@ func TestCASBlobAccessGetCapabilities(t *testing.T) {
 			return nil
 		})
 
-		serverCapabilities, err := blobAccess.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		serverCapabilities, err := blobAccess.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		require.NoError(t, err)
 		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
 			CacheCapabilities: &remoteexecution.CacheCapabilities{

--- a/pkg/builder/BUILD.bazel
+++ b/pkg/builder/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//internal/mock",
         "//pkg/digest",
         "//pkg/testutil",
+        "//pkg/util",
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@bazel_remote_apis//build/bazel/semver:semver_go_proto",
         "@com_github_stretchr_testify//require",

--- a/pkg/builder/authorizing_build_queue_test.go
+++ b/pkg/builder/authorizing_build_queue_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/builder"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -25,7 +26,7 @@ func TestAuthorizingBuildQueueGetExecutionCapabilities(t *testing.T) {
 	authorizer := mock.NewMockAuthorizer(ctrl)
 	authorizingBuildQueue := builder.NewAuthorizingBuildQueue(buildQueue, authorizer)
 
-	instanceName := digest.MustNewInstanceName("hello/world")
+	instanceName := util.Must(digest.NewInstanceName("hello/world"))
 
 	t.Run("NoExecutionCapabilities", func(t *testing.T) {
 		authorizer.EXPECT().Authorize(ctx, []digest.InstanceName{instanceName}).Return([]error{nil})
@@ -93,7 +94,7 @@ func TestAuthorizingBuildQueueExecute(t *testing.T) {
 	})
 
 	t.Run("Denied", func(t *testing.T) {
-		authorizer.EXPECT().Authorize(ctx, []digest.InstanceName{digest.MustNewInstanceName("hello/world")}).Return([]error{status.Error(codes.PermissionDenied, "Permission denied")})
+		authorizer.EXPECT().Authorize(ctx, []digest.InstanceName{util.Must(digest.NewInstanceName("hello/world"))}).Return([]error{status.Error(codes.PermissionDenied, "Permission denied")})
 		err := authorizingBuildQueue.Execute(&remoteexecution.ExecuteRequest{
 			InstanceName: "hello/world",
 			ActionDigest: &remoteexecution.Digest{
@@ -105,7 +106,7 @@ func TestAuthorizingBuildQueueExecute(t *testing.T) {
 	})
 
 	t.Run("Allowed", func(t *testing.T) {
-		authorizer.EXPECT().Authorize(ctx, []digest.InstanceName{digest.MustNewInstanceName("hello/world")}).Return([]error{nil})
+		authorizer.EXPECT().Authorize(ctx, []digest.InstanceName{util.Must(digest.NewInstanceName("hello/world"))}).Return([]error{nil})
 		buildQueue.EXPECT().Execute(&remoteexecution.ExecuteRequest{
 			InstanceName: "hello/world",
 			ActionDigest: &remoteexecution.Digest{

--- a/pkg/builder/forwarding_build_queue_test.go
+++ b/pkg/builder/forwarding_build_queue_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/builder"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc"
@@ -39,7 +40,7 @@ func TestForwardingBuildQueueGetCapabilities(t *testing.T) {
 			gomock.Any(),
 		).Return(status.Error(codes.Unavailable, "Server offline"))
 
-		_, err := buildQueue.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		_, err := buildQueue.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		testutil.RequireEqualStatus(t, status.Error(codes.Unavailable, "Server offline"), err)
 	})
 
@@ -74,7 +75,7 @@ func TestForwardingBuildQueueGetCapabilities(t *testing.T) {
 			return nil
 		})
 
-		_, err := buildQueue.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		_, err := buildQueue.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Instance name \"hello/world\" does not support remote execution"), err)
 	})
 
@@ -100,7 +101,7 @@ func TestForwardingBuildQueueGetCapabilities(t *testing.T) {
 			return nil
 		})
 
-		serverCapabilities, err := buildQueue.GetCapabilities(ctx, digest.MustNewInstanceName("hello/world"))
+		serverCapabilities, err := buildQueue.GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world")))
 		require.NoError(t, err)
 		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
 			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{

--- a/pkg/capabilities/BUILD.bazel
+++ b/pkg/capabilities/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//internal/mock",
         "//pkg/digest",
         "//pkg/testutil",
+        "//pkg/util",
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@bazel_remote_apis//build/bazel/semver:semver_go_proto",
         "@com_github_stretchr_testify//require",

--- a/pkg/capabilities/action_cache_update_enabled_clearing_provider_test.go
+++ b/pkg/capabilities/action_cache_update_enabled_clearing_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/capabilities"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -23,7 +24,7 @@ func TestActionCacheUpdateEnabledClearingProvider(t *testing.T) {
 	baseProvider := mock.NewMockCapabilitiesProvider(ctrl)
 	authorizer := mock.NewMockAuthorizer(ctrl)
 	provider := capabilities.NewActionCacheUpdateEnabledClearingProvider(baseProvider, authorizer)
-	instanceName := digest.MustNewInstanceName("hello")
+	instanceName := util.Must(digest.NewInstanceName("hello"))
 
 	t.Run("BackendFailure", func(t *testing.T) {
 		baseProvider.EXPECT().GetCapabilities(ctx, instanceName).
@@ -57,7 +58,7 @@ func TestActionCacheUpdateEnabledClearingProvider(t *testing.T) {
 					},
 				},
 			}, nil)
-		authorizer.EXPECT().Authorize(gomock.Any(), []digest.InstanceName{digest.MustNewInstanceName("hello")}).Return([]error{nil})
+		authorizer.EXPECT().Authorize(gomock.Any(), []digest.InstanceName{util.Must(digest.NewInstanceName("hello"))}).Return([]error{nil})
 
 		response, err := provider.GetCapabilities(ctx, instanceName)
 		require.NoError(t, err)
@@ -83,7 +84,7 @@ func TestActionCacheUpdateEnabledClearingProvider(t *testing.T) {
 					},
 				},
 			}, nil)
-		authorizer.EXPECT().Authorize(gomock.Any(), []digest.InstanceName{digest.MustNewInstanceName("hello")}).Return([]error{status.Error(codes.PermissionDenied, "You shall not pass")})
+		authorizer.EXPECT().Authorize(gomock.Any(), []digest.InstanceName{util.Must(digest.NewInstanceName("hello"))}).Return([]error{status.Error(codes.PermissionDenied, "You shall not pass")})
 
 		response, err := provider.GetCapabilities(ctx, instanceName)
 		require.NoError(t, err)

--- a/pkg/capabilities/merging_provider_test.go
+++ b/pkg/capabilities/merging_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/capabilities"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -19,7 +20,7 @@ import (
 
 func TestMergingProviderZero(t *testing.T) {
 	provider := capabilities.NewMergingProvider(nil)
-	instanceName := digest.MustNewInstanceName("example")
+	instanceName := util.Must(digest.NewInstanceName("example"))
 
 	t.Run("Failure", func(t *testing.T) {
 		_, err := provider.GetCapabilities(context.Background(), instanceName)
@@ -32,7 +33,7 @@ func TestMergingProviderOne(t *testing.T) {
 
 	baseProvider := mock.NewMockCapabilitiesProvider(ctrl)
 	provider := capabilities.NewMergingProvider([]capabilities.Provider{baseProvider})
-	instanceName := digest.MustNewInstanceName("example")
+	instanceName := util.Must(digest.NewInstanceName("example"))
 
 	t.Run("Success", func(t *testing.T) {
 		baseProvider.EXPECT().GetCapabilities(gomock.Any(), instanceName).
@@ -67,7 +68,7 @@ func TestMergingProviderMultiple(t *testing.T) {
 		contentAddressableStorage,
 		scheduler,
 	})
-	instanceName := digest.MustNewInstanceName("example")
+	instanceName := util.Must(digest.NewInstanceName("example"))
 
 	t.Run("AllNotFound", func(t *testing.T) {
 		actionCache.EXPECT().GetCapabilities(gomock.Any(), instanceName).

--- a/pkg/capabilities/server_test.go
+++ b/pkg/capabilities/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/capabilities"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -32,7 +33,7 @@ func TestServer(t *testing.T) {
 	})
 
 	t.Run("BackendFailure", func(t *testing.T) {
-		provider.EXPECT().GetCapabilities(ctx, digest.MustNewInstanceName("hello/world")).
+		provider.EXPECT().GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world"))).
 			Return(nil, status.Error(codes.Internal, "Server offline"))
 
 		_, err := server.GetCapabilities(ctx, &remoteexecution.GetCapabilitiesRequest{
@@ -42,7 +43,7 @@ func TestServer(t *testing.T) {
 	})
 
 	t.Run("Success", func(t *testing.T) {
-		provider.EXPECT().GetCapabilities(ctx, digest.MustNewInstanceName("hello/world")).
+		provider.EXPECT().GetCapabilities(ctx, util.Must(digest.NewInstanceName("hello/world"))).
 			Return(&remoteexecution.ServerCapabilities{
 				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
 					DigestFunction:  remoteexecution.DigestFunction_SHA256,

--- a/pkg/capabilities/static_provider_test.go
+++ b/pkg/capabilities/static_provider_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/capabilities"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,7 +21,7 @@ func TestStaticProvider(t *testing.T) {
 		},
 	})
 
-	serverCapabilities, err := provider.GetCapabilities(context.Background(), digest.MustNewInstanceName("example"))
+	serverCapabilities, err := provider.GetCapabilities(context.Background(), util.Must(digest.NewInstanceName("example")))
 	require.NoError(t, err)
 	testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
 		ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{

--- a/pkg/digest/BUILD.bazel
+++ b/pkg/digest/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//internal/mock",
         "//pkg/eviction",
         "//pkg/testutil",
+        "//pkg/util",
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@com_github_google_uuid//:uuid",
         "@com_github_stretchr_testify//require",

--- a/pkg/digest/digest_test.go
+++ b/pkg/digest/digest_test.go
@@ -6,6 +6,7 @@ import (
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
@@ -330,7 +331,7 @@ func TestDigestGetProto(t *testing.T) {
 func TestDigestGetInstanceName(t *testing.T) {
 	require.Equal(
 		t,
-		digest.MustNewInstanceName("hello"),
+		util.Must(digest.NewInstanceName("hello")),
 		digest.MustNewDigest(
 			"hello",
 			remoteexecution.DigestFunction_SHA256,

--- a/pkg/digest/instance_name.go
+++ b/pkg/digest/instance_name.go
@@ -77,17 +77,6 @@ func NewInstanceNameFromComponents(components []string) (InstanceName, error) {
 	}, nil
 }
 
-// MustNewInstanceName is identical to NewInstanceName, except that it
-// panics in case the instance name is invalid. This function can be
-// used as part of unit tests.
-func MustNewInstanceName(value string) InstanceName {
-	instanceName, err := NewInstanceName(value)
-	if err != nil {
-		panic(err)
-	}
-	return instanceName
-}
-
 // NewDigestFromCompactBinary constructs a Digest object by reading data
 // from a ByteReader that contains data that was generated using
 // Digest.GetCompactBinary().

--- a/pkg/digest/instance_name_patcher_test.go
+++ b/pkg/digest/instance_name_patcher_test.go
@@ -5,14 +5,15 @@ import (
 
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-storage/pkg/digest"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
 func testPatcher(t *testing.T, ip digest.InstanceNamePatcher, oldInstanceName, newInstanceName string) {
 	require.Equal(
 		t,
-		digest.MustNewInstanceName(newInstanceName),
-		ip.PatchInstanceName(digest.MustNewInstanceName(oldInstanceName)))
+		util.Must(digest.NewInstanceName(newInstanceName)),
+		ip.PatchInstanceName(util.Must(digest.NewInstanceName(oldInstanceName))))
 	require.Equal(
 		t,
 		digest.MustNewDigest(newInstanceName, remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5),
@@ -36,8 +37,8 @@ func TestInstanceNamePatcher(t *testing.T) {
 
 	t.Run("IdentityNonEmpty", func(t *testing.T) {
 		ip := digest.NewInstanceNamePatcher(
-			digest.MustNewInstanceName("a/b/c"),
-			digest.MustNewInstanceName("a/b/c"),
+			util.Must(digest.NewInstanceName("a/b/c")),
+			util.Must(digest.NewInstanceName("a/b/c")),
 		)
 
 		testPatcher(t, ip, "a/b/c", "a/b/c")
@@ -47,7 +48,7 @@ func TestInstanceNamePatcher(t *testing.T) {
 	t.Run("GrowEmpty", func(t *testing.T) {
 		ip := digest.NewInstanceNamePatcher(
 			digest.EmptyInstanceName,
-			digest.MustNewInstanceName("a"),
+			util.Must(digest.NewInstanceName("a")),
 		)
 
 		testPatcher(t, ip, "", "a")
@@ -56,8 +57,8 @@ func TestInstanceNamePatcher(t *testing.T) {
 
 	t.Run("GrowNonEmpty", func(t *testing.T) {
 		ip := digest.NewInstanceNamePatcher(
-			digest.MustNewInstanceName("a"),
-			digest.MustNewInstanceName("a/b"),
+			util.Must(digest.NewInstanceName("a")),
+			util.Must(digest.NewInstanceName("a/b")),
 		)
 
 		testPatcher(t, ip, "a", "a/b")
@@ -66,7 +67,7 @@ func TestInstanceNamePatcher(t *testing.T) {
 
 	t.Run("ShrinkEmpty", func(t *testing.T) {
 		ip := digest.NewInstanceNamePatcher(
-			digest.MustNewInstanceName("a"),
+			util.Must(digest.NewInstanceName("a")),
 			digest.EmptyInstanceName,
 		)
 
@@ -76,8 +77,8 @@ func TestInstanceNamePatcher(t *testing.T) {
 
 	t.Run("ShrinkNonEmpty", func(t *testing.T) {
 		ip := digest.NewInstanceNamePatcher(
-			digest.MustNewInstanceName("a/b"),
-			digest.MustNewInstanceName("a"),
+			util.Must(digest.NewInstanceName("a/b")),
+			util.Must(digest.NewInstanceName("a")),
 		)
 
 		testPatcher(t, ip, "a/b", "a")
@@ -86,8 +87,8 @@ func TestInstanceNamePatcher(t *testing.T) {
 
 	t.Run("ChangePrefix", func(t *testing.T) {
 		ip := digest.NewInstanceNamePatcher(
-			digest.MustNewInstanceName("a"),
-			digest.MustNewInstanceName("b"),
+			util.Must(digest.NewInstanceName("a")),
+			util.Must(digest.NewInstanceName("b")),
 		)
 
 		testPatcher(t, ip, "a", "b")

--- a/pkg/digest/instance_name_test.go
+++ b/pkg/digest/instance_name_test.go
@@ -7,6 +7,7 @@ import (
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -41,7 +42,7 @@ func TestNewInstanceName(t *testing.T) {
 }
 
 func TestInstanceNameGetDigestFunction(t *testing.T) {
-	instanceName := digest.MustNewInstanceName("hello")
+	instanceName := util.Must(digest.NewInstanceName("hello"))
 
 	t.Run("UnknownDigestFunction", func(t *testing.T) {
 		_, err := instanceName.GetDigestFunction(remoteexecution.DigestFunction_UNKNOWN, 0)
@@ -94,16 +95,16 @@ func TestInstanceNameGetComponents(t *testing.T) {
 	require.Equal(
 		t,
 		[]string{"hello"},
-		digest.MustNewInstanceName("hello").GetComponents())
+		util.Must(digest.NewInstanceName("hello")).GetComponents())
 
 	require.Equal(
 		t,
 		[]string{"hello", "world"},
-		digest.MustNewInstanceName("hello/world").GetComponents())
+		util.Must(digest.NewInstanceName("hello/world")).GetComponents())
 }
 
 func TestInstanceNameNewDigestFromCompactBinary(t *testing.T) {
-	instanceName := digest.MustNewInstanceName("hello")
+	instanceName := util.Must(digest.NewInstanceName("hello"))
 
 	t.Run("SHA256", func(t *testing.T) {
 		blobDigest, err := instanceName.NewDigestFromCompactBinary(bytes.NewBuffer([]byte{

--- a/pkg/digest/instance_name_trie_test.go
+++ b/pkg/digest/instance_name_trie_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/buildbarn/bb-storage/pkg/digest"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -17,114 +18,114 @@ func TestInstanceNameTrie(t *testing.T) {
 		require.Equal(t, -1, it.GetLongestPrefix(digest.EmptyInstanceName))
 		require.False(t, it.ContainsPrefix(digest.EmptyInstanceName))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("hello")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("hello")))
-		require.Equal(t, -1, it.GetLongestPrefix(digest.MustNewInstanceName("hello")))
-		require.False(t, it.ContainsPrefix(digest.MustNewInstanceName("hello")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("hello"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("hello"))))
+		require.Equal(t, -1, it.GetLongestPrefix(util.Must(digest.NewInstanceName("hello"))))
+		require.False(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("hello"))))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("hello/world")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("hello/world")))
-		require.Equal(t, -1, it.GetLongestPrefix(digest.MustNewInstanceName("hello/world")))
-		require.False(t, it.ContainsPrefix(digest.MustNewInstanceName("hello/world")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("hello/world"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("hello/world"))))
+		require.Equal(t, -1, it.GetLongestPrefix(util.Must(digest.NewInstanceName("hello/world"))))
+		require.False(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("hello/world"))))
 	})
 
 	t.Run("WithoutRoot", func(t *testing.T) {
 		// Attempt to perform lookups on a trie that does not
 		// have a root node.
 		it := digest.NewInstanceNameTrie()
-		it.Set(digest.MustNewInstanceName("a"), 123)
-		it.Set(digest.MustNewInstanceName("a/b/c"), 456)
-		it.Set(digest.MustNewInstanceName("a/b/c/d/e"), 789)
+		it.Set(util.Must(digest.NewInstanceName("a")), 123)
+		it.Set(util.Must(digest.NewInstanceName("a/b/c")), 456)
+		it.Set(util.Must(digest.NewInstanceName("a/b/c/d/e")), 789)
 
 		require.Equal(t, -1, it.GetExact(digest.EmptyInstanceName))
 		require.False(t, it.ContainsExact(digest.EmptyInstanceName))
 		require.Equal(t, -1, it.GetLongestPrefix(digest.EmptyInstanceName))
 		require.False(t, it.ContainsPrefix(digest.EmptyInstanceName))
 
-		require.Equal(t, 123, it.GetExact(digest.MustNewInstanceName("a")))
-		require.True(t, it.ContainsExact(digest.MustNewInstanceName("a")))
-		require.Equal(t, 123, it.GetLongestPrefix(digest.MustNewInstanceName("a")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a")))
+		require.Equal(t, 123, it.GetExact(util.Must(digest.NewInstanceName("a"))))
+		require.True(t, it.ContainsExact(util.Must(digest.NewInstanceName("a"))))
+		require.Equal(t, 123, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a"))))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("a/b")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("a/b")))
-		require.Equal(t, 123, it.GetLongestPrefix(digest.MustNewInstanceName("a/b")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("a/b"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b"))))
+		require.Equal(t, 123, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b"))))
 
-		require.Equal(t, 456, it.GetExact(digest.MustNewInstanceName("a/b/c")))
-		require.True(t, it.ContainsExact(digest.MustNewInstanceName("a/b/c")))
-		require.Equal(t, 456, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c")))
+		require.Equal(t, 456, it.GetExact(util.Must(digest.NewInstanceName("a/b/c"))))
+		require.True(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b/c"))))
+		require.Equal(t, 456, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c"))))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("a/b/c/d")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("a/b/c/d")))
-		require.Equal(t, 456, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c/d")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c/d")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("a/b/c/d"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b/c/d"))))
+		require.Equal(t, 456, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c/d"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c/d"))))
 
-		require.Equal(t, 789, it.GetExact(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.True(t, it.ContainsExact(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.Equal(t, 789, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c/d/e")))
+		require.Equal(t, 789, it.GetExact(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.True(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.Equal(t, 789, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("a/b/c/d/e/f")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("a/b/c/d/e/f")))
-		require.Equal(t, 789, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c/d/e/f")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c/d/e/f")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("a/b/c/d/e/f"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b/c/d/e/f"))))
+		require.Equal(t, 789, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e/f"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e/f"))))
 
 		// Removing all entries should make all instance names
 		// unresolvable.
-		require.False(t, it.Remove(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.False(t, it.Remove(digest.MustNewInstanceName("a")))
-		require.True(t, it.Remove(digest.MustNewInstanceName("a/b/c")))
+		require.False(t, it.Remove(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.False(t, it.Remove(util.Must(digest.NewInstanceName("a"))))
+		require.True(t, it.Remove(util.Must(digest.NewInstanceName("a/b/c"))))
 
-		require.Equal(t, -1, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c/d/e/f")))
-		require.False(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c/d/e/f")))
+		require.Equal(t, -1, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e/f"))))
+		require.False(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e/f"))))
 	})
 
 	t.Run("WithRoot", func(t *testing.T) {
 		// Attempt to perform lookups on a trie that has a root node.
 		it := digest.NewInstanceNameTrie()
 		it.Set(digest.EmptyInstanceName, 123)
-		it.Set(digest.MustNewInstanceName("a/b"), 456)
-		it.Set(digest.MustNewInstanceName("a/b/c/d"), 789)
+		it.Set(util.Must(digest.NewInstanceName("a/b")), 456)
+		it.Set(util.Must(digest.NewInstanceName("a/b/c/d")), 789)
 
 		require.Equal(t, 123, it.GetExact(digest.EmptyInstanceName))
 		require.True(t, it.ContainsExact(digest.EmptyInstanceName))
 		require.Equal(t, 123, it.GetLongestPrefix(digest.EmptyInstanceName))
 		require.True(t, it.ContainsPrefix(digest.EmptyInstanceName))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("a")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("a")))
-		require.Equal(t, 123, it.GetLongestPrefix(digest.MustNewInstanceName("a")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("a"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("a"))))
+		require.Equal(t, 123, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a"))))
 
-		require.Equal(t, 456, it.GetExact(digest.MustNewInstanceName("a/b")))
-		require.True(t, it.ContainsExact(digest.MustNewInstanceName("a/b")))
-		require.Equal(t, 456, it.GetLongestPrefix(digest.MustNewInstanceName("a/b")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b")))
+		require.Equal(t, 456, it.GetExact(util.Must(digest.NewInstanceName("a/b"))))
+		require.True(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b"))))
+		require.Equal(t, 456, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b"))))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("a/b/c")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("a/b/c")))
-		require.Equal(t, 456, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("a/b/c"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b/c"))))
+		require.Equal(t, 456, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c"))))
 
-		require.Equal(t, 789, it.GetExact(digest.MustNewInstanceName("a/b/c/d")))
-		require.True(t, it.ContainsExact(digest.MustNewInstanceName("a/b/c/d")))
-		require.Equal(t, 789, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c/d")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c/d")))
+		require.Equal(t, 789, it.GetExact(util.Must(digest.NewInstanceName("a/b/c/d"))))
+		require.True(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b/c/d"))))
+		require.Equal(t, 789, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c/d"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c/d"))))
 
-		require.Equal(t, -1, it.GetExact(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.False(t, it.ContainsExact(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.Equal(t, 789, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.True(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c/d/e")))
+		require.Equal(t, -1, it.GetExact(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.False(t, it.ContainsExact(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.Equal(t, 789, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.True(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
 
 		// Removing all entries should make all instance names
 		// unresolvable.
 		require.False(t, it.Remove(digest.EmptyInstanceName))
-		require.False(t, it.Remove(digest.MustNewInstanceName("a/b")))
-		require.True(t, it.Remove(digest.MustNewInstanceName("a/b/c/d")))
+		require.False(t, it.Remove(util.Must(digest.NewInstanceName("a/b"))))
+		require.True(t, it.Remove(util.Must(digest.NewInstanceName("a/b/c/d"))))
 
-		require.Equal(t, -1, it.GetLongestPrefix(digest.MustNewInstanceName("a/b/c/d/e")))
-		require.False(t, it.ContainsPrefix(digest.MustNewInstanceName("a/b/c/d/e")))
+		require.Equal(t, -1, it.GetLongestPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
+		require.False(t, it.ContainsPrefix(util.Must(digest.NewInstanceName("a/b/c/d/e"))))
 	})
 }

--- a/pkg/grpc/BUILD.bazel
+++ b/pkg/grpc/BUILD.bazel
@@ -129,6 +129,7 @@ go_test(
         "//pkg/proto/auth",
         "//pkg/proto/configuration/grpc",
         "//pkg/testutil",
+        "//pkg/util",
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto",
         "@com_github_jmespath_go_jmespath//:go-jmespath",
         "@com_github_stretchr_testify//require",

--- a/pkg/grpc/all_authenticator_test.go
+++ b/pkg/grpc/all_authenticator_test.go
@@ -9,6 +9,7 @@ import (
 	bb_grpc "github.com/buildbarn/bb-storage/pkg/grpc"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -50,9 +51,9 @@ func TestAllAuthenticatorMultiple(t *testing.T) {
 	t.Run("SecondFailure", func(t *testing.T) {
 		// There is no need to check the other authentication
 		// backends if the first already returns failure.
-		m0.EXPECT().Authenticate(ctx).Return(auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+		m0.EXPECT().Authenticate(ctx).Return(util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 			Public: structpb.NewStringValue("You're totally who you say you are"),
-		}), nil)
+		})), nil)
 		m1.EXPECT().Authenticate(ctx).Return(nil, status.Error(codes.Unauthenticated, "No token present"))
 
 		_, err := a.Authenticate(ctx)
@@ -101,7 +102,7 @@ func TestAllAuthenticatorMultiple(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		m0.EXPECT().Authenticate(ctx).Return(auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+		m0.EXPECT().Authenticate(ctx).Return(util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 			Public:  structpb.NewStructValue(publicStruct0),
 			Private: structpb.NewStructValue(privateStruct0),
 			TracingAttributes: []*v1.KeyValue{
@@ -114,8 +115,8 @@ func TestAllAuthenticatorMultiple(t *testing.T) {
 					},
 				},
 			},
-		}), nil)
-		m1.EXPECT().Authenticate(ctx).Return(auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+		})), nil)
+		m1.EXPECT().Authenticate(ctx).Return(util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 			Public:  structpb.NewStructValue(publicStruct1),
 			Private: structpb.NewStructValue(privateStruct1),
 			TracingAttributes: []*v1.KeyValue{
@@ -128,7 +129,7 @@ func TestAllAuthenticatorMultiple(t *testing.T) {
 					},
 				},
 			},
-		}), nil)
+		})), nil)
 		metadata, err := a.Authenticate(ctx)
 		require.NoError(t, err)
 		require.Equal(t, map[string]any{

--- a/pkg/grpc/allow_authenticator_test.go
+++ b/pkg/grpc/allow_authenticator_test.go
@@ -7,19 +7,20 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	bb_grpc "github.com/buildbarn/bb-storage/pkg/grpc"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
 func TestAllowAuthenticator(t *testing.T) {
-	expectedMetadata := auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	expectedMetadata := util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Public: structpb.NewStructValue(&structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"username": structpb.NewStringValue("John Doe"),
 			},
 		}),
-	})
+	}))
 	a := bb_grpc.NewAllowAuthenticator(expectedMetadata)
 	actualMetadata, err := a.Authenticate(context.Background())
 	require.NoError(t, err)

--- a/pkg/grpc/any_authenticator_test.go
+++ b/pkg/grpc/any_authenticator_test.go
@@ -9,6 +9,7 @@ import (
 	bb_grpc "github.com/buildbarn/bb-storage/pkg/grpc"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -40,9 +41,9 @@ func TestAnyAuthenticatorMultiple(t *testing.T) {
 		// There is no need to check the third authentication
 		// backend if the second already returns success.
 		m0.EXPECT().Authenticate(ctx).Return(nil, status.Error(codes.Unauthenticated, "No token present"))
-		m1.EXPECT().Authenticate(ctx).Return(auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+		m1.EXPECT().Authenticate(ctx).Return(util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 			Public: structpb.NewStringValue("You're totally who you say you are"),
-		}), nil)
+		})), nil)
 
 		metadata, err := a.Authenticate(ctx)
 		require.NoError(t, err)
@@ -98,9 +99,9 @@ func TestAnyAuthenticatorMultiple(t *testing.T) {
 		// going down entirely.
 		m0.EXPECT().Authenticate(ctx).Return(nil, status.Error(codes.Unauthenticated, "No TLS used"))
 		m1.EXPECT().Authenticate(ctx).Return(nil, status.Error(codes.Internal, "Failed to contact OAuth2 server"))
-		m2.EXPECT().Authenticate(ctx).Return(auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+		m2.EXPECT().Authenticate(ctx).Return(util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 			Public: structpb.NewStringValue("You're totally who you say you are"),
-		}), nil)
+		})), nil)
 
 		metadata, err := a.Authenticate(ctx)
 		require.NoError(t, err)

--- a/pkg/grpc/jmespath_extractor_test.go
+++ b/pkg/grpc/jmespath_extractor_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/grpc"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/jmespath/go-jmespath"
 	"github.com/stretchr/testify/require"
 
@@ -37,9 +38,9 @@ func TestJMESPathMetadataExtractorSimple(t *testing.T) {
 		"hdr-from-both", "boop",
 	})...)
 
-	ctx := auth.NewContextWithAuthenticationMetadata(context.Background(), auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	ctx := auth.NewContextWithAuthenticationMetadata(context.Background(), util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Public: structpb.NewStringValue("boop"),
-	}))
+	})))
 
 	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs("whiz", "bang"))
 
@@ -56,9 +57,9 @@ func TestJMESPathMetadataExtractorAuthMatchToString(t *testing.T) {
 
 	// The resulting header value must be a list. Yielding a string
 	// value directly should cause an error.
-	ctx := auth.NewContextWithAuthenticationMetadata(context.Background(), auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	ctx := auth.NewContextWithAuthenticationMetadata(context.Background(), util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Public: structpb.NewStringValue("boop"),
-	}))
+	})))
 
 	_, err = extractor(ctx)
 	testutil.RequireEqualStatus(t, status.Errorf(codes.InvalidArgument, "Failed to extract JMESPath result: Non-slice metadata value"), err)
@@ -70,14 +71,14 @@ func TestJMESPathMetadataExtractorAuthMatchToHeterogenousSlice(t *testing.T) {
 
 	// Each of the header values should be a valid string. Integer
 	// values are not permitted.
-	ctx := auth.NewContextWithAuthenticationMetadata(context.Background(), auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	ctx := auth.NewContextWithAuthenticationMetadata(context.Background(), util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Public: structpb.NewListValue(&structpb.ListValue{
 			Values: []*structpb.Value{
 				structpb.NewStringValue("boop"),
 				structpb.NewNumberValue(1),
 			},
 		}),
-	}))
+	})))
 
 	_, err = extractor(ctx)
 	testutil.RequireEqualStatus(t, status.Errorf(codes.InvalidArgument, "Failed to extract JMESPath result: Non-string metadata value"), err)

--- a/pkg/grpc/metadata_extracting_and_forwarding_interceptor_test.go
+++ b/pkg/grpc/metadata_extracting_and_forwarding_interceptor_test.go
@@ -12,6 +12,7 @@ import (
 	bb_grpc "github.com/buildbarn/bb-storage/pkg/grpc"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc"
@@ -25,13 +26,13 @@ import (
 func TestMetadataExtractingAndForwardingUnaryClientInterceptor(t *testing.T) {
 	ctrl, ctx := gomock.WithContext(context.Background(), t)
 
-	modifiedCtx := auth.NewContextWithAuthenticationMetadata(ctx, auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	modifiedCtx := auth.NewContextWithAuthenticationMetadata(ctx, util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Private: structpb.NewStructValue(&structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"header": structpb.NewStringValue("value"),
 			},
 		}),
-	}))
+	})))
 	invoker := mock.NewMockUnaryInvoker(ctrl)
 	req := &emptypb.Empty{}
 	resp := &emptypb.Empty{}
@@ -75,13 +76,13 @@ func TestMetadataExtractingAndForwardingUnaryClientInterceptor(t *testing.T) {
 func TestMetadataExtractingAndForwardingStreamClientInterceptor(t *testing.T) {
 	ctrl, ctx := gomock.WithContext(context.Background(), t)
 
-	modifiedCtx := auth.NewContextWithAuthenticationMetadata(ctx, auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	modifiedCtx := auth.NewContextWithAuthenticationMetadata(ctx, util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Private: structpb.NewStructValue(&structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"header": structpb.NewStringValue("value"),
 			},
 		}),
-	}))
+	})))
 	streamDesc := grpc.StreamDesc{StreamName: "SomeMethod"}
 	streamer := mock.NewMockStreamer(ctrl)
 	clientStream := mock.NewMockClientStream(ctrl)

--- a/pkg/grpc/request_headers_authenticator_test.go
+++ b/pkg/grpc/request_headers_authenticator_test.go
@@ -9,12 +9,15 @@ import (
 	bb_grpc "github.com/buildbarn/bb-storage/pkg/grpc"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"go.uber.org/mock/gomock"
 )
 
 func TestRequestHeadersAuthenticator(t *testing.T) {
@@ -38,9 +41,9 @@ func TestRequestHeadersAuthenticator(t *testing.T) {
 				// MissingHeader is not part of the request.
 				// UnusedHeader should not be passed.
 			},
-		).Return(auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+		).Return(util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 			Public: structpb.NewStringValue("You're totally who you say you are"),
-		}), nil)
+		})), nil)
 
 		authenticator := bb_grpc.NewRequestHeadersAuthenticator(
 			backend,

--- a/pkg/grpc/tls_client_certificate_authenticator_test.go
+++ b/pkg/grpc/tls_client_certificate_authenticator_test.go
@@ -13,6 +13,7 @@ import (
 	bb_grpc "github.com/buildbarn/bb-storage/pkg/grpc"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/jmespath/go-jmespath"
 	"github.com/stretchr/testify/require"
 
@@ -103,7 +104,7 @@ func TestTLSClientCertificateAuthenticator(t *testing.T) {
 	clientCAs := x509.NewCertPool()
 	clientCAs.AddCert(certificateValid)
 	clock := mock.NewMockClock(ctrl)
-	expectedMetadata := auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	expectedMetadata := util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Public: structpb.NewStructValue(&structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"dnsNames": structpb.NewListValue(&structpb.ListValue{
@@ -123,7 +124,7 @@ func TestTLSClientCertificateAuthenticator(t *testing.T) {
 				}),
 			},
 		}),
-	})
+	}))
 
 	aValidator := jmespath.MustCompile(`contains(dnsNames, 'a.example.com')`)
 	bValidator := jmespath.MustCompile(`contains(dnsNames, 'b.example.com')`)

--- a/pkg/http/BUILD.bazel
+++ b/pkg/http/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/proto/auth",
         "//pkg/proto/http/oidc",
         "//pkg/testutil",
+        "//pkg/util",
         "@com_github_jmespath_go_jmespath//:go-jmespath",
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//codes",

--- a/pkg/http/accept_header_authenticator_test.go
+++ b/pkg/http/accept_header_authenticator_test.go
@@ -9,6 +9,7 @@ import (
 	bb_http "github.com/buildbarn/bb-storage/pkg/http"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/grpc/codes"
@@ -54,13 +55,13 @@ func TestAcceptHeaderAuthenticator(t *testing.T) {
 			require.NoError(t, err)
 			r.Header.Set("Accept", header)
 
-			expectedMetadata := auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+			expectedMetadata := util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 				Public: structpb.NewStructValue(&structpb.Struct{
 					Fields: map[string]*structpb.Value{
 						"username": structpb.NewStringValue("John Doe"),
 					},
 				}),
-			})
+			}))
 			baseAuthenticator.EXPECT().Authenticate(w, r).Return(expectedMetadata, nil)
 
 			actualMetadata, err := authenticator.Authenticate(w, r)

--- a/pkg/http/allow_authenticator_test.go
+++ b/pkg/http/allow_authenticator_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/auth"
 	bb_http "github.com/buildbarn/bb-storage/pkg/http"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/protobuf/types/known/structpb"
@@ -18,13 +19,13 @@ import (
 func TestAllowAuthenticator(t *testing.T) {
 	ctrl := gomock.NewController(t)
 
-	expectedMetadata := auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+	expectedMetadata := util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 		Public: structpb.NewStructValue(&structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"username": structpb.NewStringValue("John Doe"),
 			},
 		}),
-	})
+	}))
 	authenticator := bb_http.NewAllowAuthenticator(expectedMetadata)
 
 	w := mock.NewMockResponseWriter(ctrl)

--- a/pkg/http/request_headers_authenticator_test.go
+++ b/pkg/http/request_headers_authenticator_test.go
@@ -10,11 +10,14 @@ import (
 	bb_http "github.com/buildbarn/bb-storage/pkg/http"
 	auth_pb "github.com/buildbarn/bb-storage/pkg/proto/auth"
 	"github.com/buildbarn/bb-storage/pkg/testutil"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/mock/gomock"
+
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"go.uber.org/mock/gomock"
 )
 
 func TestRequestHeadersAuthenticator(t *testing.T) {
@@ -36,9 +39,9 @@ func TestRequestHeadersAuthenticator(t *testing.T) {
 				// MissingHeader is not part of the request.
 				// UnusedHeader should not be passed.
 			},
-		).Return(auth.MustNewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
+		).Return(util.Must(auth.NewAuthenticationMetadataFromProto(&auth_pb.AuthenticationMetadata{
 			Public: structpb.NewStringValue("You're totally who you say you are"),
-		}), nil)
+		})), nil)
 
 		authenticator, err := bb_http.NewRequestHeadersAuthenticator(
 			backend,

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "buckets.go",
         "error_logger.go",
         "jsonnet.go",
+        "must.go",
         "non_empty_stack.go",
         "proto.go",
         "semaphore.go",

--- a/pkg/util/must.go
+++ b/pkg/util/must.go
@@ -1,0 +1,13 @@
+package util
+
+// Must can be used to wrap the invocation of a function that may return
+// an error, and panic if an error occurs.
+//
+// This function should only be used in situations where a failure to
+// create an object can occur if some design constraint is violated.
+func Must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}


### PR DESCRIPTION
We currently have a couple of MustNew*() functions in our tree. Now that we have generics, let's add a small helper function for this instead.