### PR TITLE
Make all container images public

### DIFF
--- a/tools/container.bzl
+++ b/tools/container.bzl
@@ -36,6 +36,7 @@ def multiarch_go_image(name, binary):
             "@rules_go//go/toolchain:linux_amd64",
             "@rules_go//go/toolchain:linux_arm64",
         ],
+        visibility = ["//visibility:public"],
     )
 
 def container_push_official(name, image, component):


### PR DESCRIPTION
It should be possible for others to make Bazel projects that depend on these images. For example, one may use rules_gitops to easily roll out Buildbarn container images on a Kubernetes cluster.