### PR TITLE
Make NewBlockDeviceFromFile more resiliant on Windows

### DIFF
--- a/pkg/blockdevice/BUILD.bazel
+++ b/pkg/blockdevice/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
             "@org_golang_x_sys//unix",
         ],
         "@rules_go//go/platform:windows": [
+            "//pkg/filesystem/path",
             "//pkg/util",
             "@org_golang_x_sys//windows",
         ],

--- a/pkg/blockdevice/new_block_device_from_file_windows_test.go
+++ b/pkg/blockdevice/new_block_device_from_file_windows_test.go
@@ -12,20 +12,45 @@ import (
 
 func TestRootPathForPath(t *testing.T) {
 	t.Run("ConventionalDiskPath", func(t *testing.T) {
-		require.Equal(t, `C:\`, blockdevice.RootPathForPath(`C:\`))
-		require.Equal(t, `C:\`, blockdevice.RootPathForPath(`C:\somefolder`))
-		require.Equal(t, `C:\`, blockdevice.RootPathForPath(`C:\somefolder\somefile.txt`))
+		path, err := blockdevice.RootPathForPath(`C:\`)
+		require.NoError(t, err)
+		require.Equal(t, `C:\`, path)
+
+		path, err = blockdevice.RootPathForPath(`C:\somefolder`)
+		require.NoError(t, err)
+		require.Equal(t, `C:\`, path)
+
+		path, err = blockdevice.RootPathForPath(`C:\somefolder\somefile.txt`)
+		require.NoError(t, err)
+		require.Equal(t, `C:\`, path)
+
+		path, err = blockdevice.RootPathForPath(`C:/somefolder/somefile.txt`)
+		require.NoError(t, err)
+		require.Equal(t, `C:\`, path)
 	})
 
 	t.Run("UNCPath", func(t *testing.T) {
 		// Test UNC paths (\\server\share)
-		require.Equal(t, `\\server\share\`, blockdevice.RootPathForPath(`\\server\share\`))
-		require.Equal(t, `\\server\share\`, blockdevice.RootPathForPath(`\\server\share\folder`))
-		require.Equal(t, `\\server\share\`, blockdevice.RootPathForPath(`\\server\share\folder\file.txt`))
+		path, err := blockdevice.RootPathForPath(`\\server\share\`)
+		require.NoError(t, err)
+		require.Equal(t, `\\server\share\`, path)
+
+		path, err = blockdevice.RootPathForPath(`\\server\share\folder\file.txt`)
+		require.NoError(t, err)
+		require.Equal(t, `\\server\share\`, path)
+
+		path, err = blockdevice.RootPathForPath(`\\server\share/file.txt`)
+		require.NoError(t, err)
+		require.Equal(t, `\\server\share\`, path)
+
+		path, err = blockdevice.RootPathForPath(`//server/share/file.txt`)
+		require.NoError(t, err)
+		require.Equal(t, `\\server\share\`, path)
 	})
 
 	t.Run("UnknownPath", func(t *testing.T) {
 		// Test unhandled paths
-		require.Equal(t, "/uhoh/share", blockdevice.RootPathForPath("/uhoh/share"))
+		_, err := blockdevice.RootPathForPath("/uhoh/share")
+		require.Error(t, err)
 	})
 }

--- a/pkg/filesystem/path/absolute_scope_walker.go
+++ b/pkg/filesystem/path/absolute_scope_walker.go
@@ -28,3 +28,7 @@ func (pw *absoluteScopeWalker) OnAbsolute() (ComponentWalker, error) {
 func (pw *absoluteScopeWalker) OnDriveLetter(drive rune) (ComponentWalker, error) {
 	return pw.componentWalker, nil
 }
+
+func (pw *absoluteScopeWalker) OnShare(server, share string) (ComponentWalker, error) {
+	return pw.componentWalker, nil
+}

--- a/pkg/filesystem/path/loop_detecting_scope_walker.go
+++ b/pkg/filesystem/path/loop_detecting_scope_walker.go
@@ -56,6 +56,17 @@ func (w *loopDetectingScopeWalker) OnRelative() (ComponentWalker, error) {
 	}, nil
 }
 
+func (w *loopDetectingScopeWalker) OnShare(server, share string) (ComponentWalker, error) {
+	componentWalker, err := w.base.OnShare(server, share)
+	if err != nil {
+		return nil, err
+	}
+	return &loopDetectingComponentWalker{
+		base:         componentWalker,
+		symlinksLeft: w.symlinksLeft,
+	}, nil
+}
+
 type loopDetectingComponentWalker struct {
 	base         ComponentWalker
 	symlinksLeft int

--- a/pkg/filesystem/path/relative_scope_walker.go
+++ b/pkg/filesystem/path/relative_scope_walker.go
@@ -28,3 +28,7 @@ func (pw *relativeScopeWalker) OnDriveLetter(drive rune) (ComponentWalker, error
 func (pw *relativeScopeWalker) OnRelative() (ComponentWalker, error) {
 	return pw.componentWalker, nil
 }
+
+func (pw *relativeScopeWalker) OnShare(server, share string) (ComponentWalker, error) {
+	return nil, status.Error(codes.InvalidArgument, "Path has a UNC prefix, while a relative path was expected")
+}

--- a/pkg/filesystem/path/scope_walker.go
+++ b/pkg/filesystem/path/scope_walker.go
@@ -9,7 +9,8 @@ type ScopeWalker interface {
 	// characteristics of the path. Absolute paths are handled through
 	// OnAbsolute(), and relative paths require OnRelative(). On Windows
 	// absolute paths can also start with a drive letter, which is handled
-	// through OnDriveLetter().
+	// through OnDriveLetter(), or as a UNC path, which is handled through
+	// OnShare.
 	//
 	// These functions can be used by the implementation to determine
 	// whether path resolution needs to be relative to the current
@@ -28,4 +29,5 @@ type ScopeWalker interface {
 	OnAbsolute() (ComponentWalker, error)
 	OnRelative() (ComponentWalker, error)
 	OnDriveLetter(drive rune) (ComponentWalker, error)
+	OnShare(server, share string) (ComponentWalker, error)
 }

--- a/pkg/filesystem/path/virtual_root_scope_walker_factory.go
+++ b/pkg/filesystem/path/virtual_root_scope_walker_factory.go
@@ -217,6 +217,10 @@ func (w *virtualRootScopeWalker) OnRelative() (ComponentWalker, error) {
 	}, nil
 }
 
+func (w *virtualRootScopeWalker) OnShare(server, share string) (ComponentWalker, error) {
+	return w.getComponentWalker(w.rootNode)
+}
+
 // pendingVirtualRootComponentWalker is VirtualRootScopeWalkerFactory's
 // decorator for ComponentWalker when resolution takes place inside the
 // virtual root directory (i.e., outside the underlying root directory).

--- a/pkg/filesystem/path/void_scope_walker.go
+++ b/pkg/filesystem/path/void_scope_walker.go
@@ -14,6 +14,10 @@ func (w voidScopeWalker) OnRelative() (ComponentWalker, error) {
 	return VoidComponentWalker, nil
 }
 
+func (w voidScopeWalker) OnShare(server, share string) (ComponentWalker, error) {
+	return VoidComponentWalker, nil
+}
+
 // VoidScopeWalker is an instance of ScopeWalker that accepts both
 // relative and absolute paths, and can resolve any filename. By itself
 // it is of little use. When used in combination with Builder, it can be


### PR DESCRIPTION
On Windows / and \ are both accepted as directory separators in most places. This change ensures that the we accept either when specifying the path to a block storage file.