### PR TITLE
Fix the TLS test on windows

### DIFF
--- a/pkg/util/tls_test.go
+++ b/pkg/util/tls_test.go
@@ -389,7 +389,7 @@ func TestTLSConfigFromServerConfiguration(t *testing.T) {
 			},
 			/* requestClientCertificate = */ false,
 		)
-		testutil.RequirePrefixedStatus(t, status.Error(codes.InvalidArgument, "Failed to configure server TLS: Failed to initialize certificate: Failed to read certificate file: open /missing-cert.pem: no such file or directory"), err)
+		testutil.RequirePrefixedStatus(t, status.Error(codes.InvalidArgument, "Failed to configure server TLS: Failed to initialize certificate: Failed to read certificate file: open /missing-cert.pem: "), err)
 	})
 
 	t.Run("CustomCipherSuites", func(t *testing.T) {


### PR DESCRIPTION
On Windows this fails with a slightly different error message:

  Failed to configure server TLS: Failed to initialize certificate:
  Failed to read certificate file: open /missing-cert.pem:
  The system cannot find the file specified.

This slightly weakens the test but it still checks the message is reasonably helpful.