### PR TITLE
Fix createUpgradedHandle's use of InvalidHandle

### DIFF
--- a/pkg/filesystem/local_directory_windows.go
+++ b/pkg/filesystem/local_directory_windows.go
@@ -85,7 +85,7 @@ func (d *localDirectory) createUpgradedHandle(access uint32) (windows.Handle, er
 		return windows.InvalidHandle, err
 	}
 	oa := &windows.OBJECT_ATTRIBUTES{
-		RootDirectory: windows.InvalidHandle,
+		RootDirectory: 0,
 		ObjectName: &windows.NTUnicodeString{
 			Buffer:        &path[0],
 			Length:        uint16(pathLen*2 - 2), // subtract the null terminator


### PR DESCRIPTION
This fixes a bug introduced (by me - sorry) in
48ed13203b8710ffdde5cc4441d7e58033a76957. RootDirectory needs to be 0, not InvalidHandle.
