### PR TITLE
Make //pkg/otel build on Windows

### DIFF
--- a/pkg/otel/BUILD.bazel
+++ b/pkg/otel/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@aspect_rules_js//js:defs.bzl", "js_run_binary")
 load("@com_github_buildbarn_bb_storage_npm//:purgecss/package_json.bzl", purgecss_bin = "bin")
 load("@rules_go//go:def.bzl", "go_library", "go_test")
 
@@ -66,13 +67,23 @@ purgecss_bin.purgecss_binary(
 
 # Create a copy of Bootstrap that only contains the style attributes
 # used by the HTML template.
-genrule(
+js_run_binary(
     name = "stylesheet",
     srcs = [
-        "@com_github_twbs_bootstrap//:css/bootstrap.min.css",
         "active_spans.html",
+        "@com_github_twbs_bootstrap//:css/bootstrap.min.css",
     ],
     outs = ["stylesheet.css"],
-    cmd = "BAZEL_BINDIR=$(BINDIR) $(location :purgecss) --css $${PWD}/$(location @com_github_twbs_bootstrap//:css/bootstrap.min.css) --content $${PWD}/$(location active_spans.html) --output $${PWD}/$@",
-    tools = [":purgecss"],
+    args = [
+        # js_run_binary runs in the output dir;
+        # see https://github.com/aspect-build/rules_js/blob/main/docs/migrate.md#account-for-change-to-working-directory
+        "--css",
+        "../../../$(location @com_github_twbs_bootstrap//:css/bootstrap.min.css)",
+        "--content",
+        "../../../$(location active_spans.html)",
+        "--output",
+        "../../../$(location stylesheet.css)",
+    ],
+    copy_srcs_to_bin = False,
+    tool = ":purgecss",
 )


### PR DESCRIPTION
Before this it would fail with errors such as:

	FATAL: aspect_rules_js[js_binary]: the entry_point
	'/d/b/s9/nr2w6eog/execroot/_main/bazel-out/x64_windows-fastbuild/bin
	/node_modules/.aspect_rules_js/purgecss@6.0.0/node_modules/purgecss/
	bin/purgecss.js' not found