### PR TITLE
Merge API versions in MergingProvider

### DIFF
--- a/pkg/capabilities/merging_provider.go
+++ b/pkg/capabilities/merging_provider.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/buildbarn/bb-storage/pkg/util"
 
@@ -16,6 +17,7 @@ import (
 type mergingProvider struct {
 	providers []Provider
 }
+
 
 // NewMergingProvider creates a capabilities provider that merges the
 // capabilities reported by multiple backends. It can, for example, be
@@ -41,11 +43,12 @@ func NewMergingProvider(providers []Provider) Provider {
 
 func (p *mergingProvider) GetCapabilities(ctx context.Context, instanceName digest.InstanceName) (*remoteexecution.ServerCapabilities, error) {
 	// Query all underlying providers in parallel.
-	type result struct {
+	type providerResult struct {
 		capabilities *remoteexecution.ServerCapabilities
 		err          error
 	}
-	results := make([]result, len(p.providers))
+
+	results := make([]providerResult, len(p.providers))
 	group, groupCtx := errgroup.WithContext(ctx)
 	for iIter, providerIter := range p.providers {
 		i, provider := iIter, providerIter
@@ -56,7 +59,7 @@ func (p *mergingProvider) GetCapabilities(ctx context.Context, instanceName dige
 				// Underlying provider returned
 				// CacheCapabilities,
 				// ExecutionCapabilities or both.
-				results[i] = result{
+				results[i] = providerResult{
 					capabilities: capabilities,
 				}
 				return nil
@@ -64,7 +67,7 @@ func (p *mergingProvider) GetCapabilities(ctx context.Context, instanceName dige
 				// Don't terminate if we see these
 				// errors, as other subsystems may still
 				// report other capabilities.
-				results[i] = result{
+				results[i] = providerResult{
 					capabilities: &remoteexecution.ServerCapabilities{},
 					err:          err,
 				}
@@ -78,14 +81,19 @@ func (p *mergingProvider) GetCapabilities(ctx context.Context, instanceName dige
 		return nil, err
 	}
 
-	// Merge results from all providers into a single
-	// ServerCapabilities message.
-	var capabilities remoteexecution.ServerCapabilities
+	// Collect valid capabilities for merging
+	validCapabilities := make([]*remoteexecution.ServerCapabilities, 0, len(results))
 	for _, result := range results {
-		proto.Merge(&capabilities, result.capabilities)
+		if result.capabilities != nil {
+			validCapabilities = append(validCapabilities, result.capabilities)
+		}
 	}
+
+	// Merge results from all providers into a single
+	// ServerCapabilities message with proper API version intersection.
+	capabilities := p.mergeCapabilities(validCapabilities)
 	if capabilities.CacheCapabilities != nil || capabilities.ExecutionCapabilities != nil {
-		return &capabilities, nil
+		return capabilities, nil
 	}
 
 	// None of the providers yielded any capabilities. Combine all
@@ -97,6 +105,101 @@ func (p *mergingProvider) GetCapabilities(ctx context.Context, instanceName dige
 		}
 	}
 	return nil, util.StatusFromMultiple(errs)
+}
+
+// mergeCapabilities merges capabilities from multiple providers
+// with proper API version intersection logic.
+func (p *mergingProvider) mergeCapabilities(capabilities []*remoteexecution.ServerCapabilities) *remoteexecution.ServerCapabilities {
+	var merged remoteexecution.ServerCapabilities
+	var maxLowApiVersion, minHighApiVersion, maxDeprecatedApiVersion *semver.SemVer
+
+	for _, capability := range capabilities {
+		if capability == nil {
+			continue
+		}
+
+		maxLowApiVersion = maxSemanticVersions(maxLowApiVersion, capability.LowApiVersion)
+		minHighApiVersion = minSemanticVersions(minHighApiVersion, capability.HighApiVersion)
+		maxDeprecatedApiVersion = maxSemanticVersions(maxDeprecatedApiVersion, capability.DeprecatedApiVersion)
+
+		// Null out the API version fields, so we don't pollute the proto merge
+		capability.LowApiVersion = nil
+		capability.HighApiVersion = nil
+		capability.DeprecatedApiVersion = nil
+
+		proto.Merge(&merged, capability)
+	}
+
+	// Set final API versions on merged capabilities
+	if maxLowApiVersion != nil && minHighApiVersion != nil {
+		// Check for valid intersection
+		if compareSemanticVersions(maxLowApiVersion, minHighApiVersion) <= 0 {
+			// Valid intersection exists
+			merged.LowApiVersion = maxLowApiVersion
+			merged.HighApiVersion = minHighApiVersion
+		}
+		// If no valid intersection, leave API versions nil (server.go will set defaults)
+	}
+
+	merged.DeprecatedApiVersion = maxDeprecatedApiVersion
+
+	return &merged
+}
+
+// minSemanticVersions returns the minimum of two semantic versions.
+// Treats nil as plus infinity (so non-nil always wins as minimum).
+// Returns nil if both are nil.
+func minSemanticVersions(a, b *semver.SemVer) *semver.SemVer {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if compareSemanticVersions(a, b) <= 0 {
+		return a
+	}
+	return b
+}
+
+// maxSemanticVersions returns the maximum of two semantic versions.
+// Treats nil as minus infinity (so non-nil always wins as maximum).
+// Returns nil if both are nil.
+func maxSemanticVersions(a, b *semver.SemVer) *semver.SemVer {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if compareSemanticVersions(a, b) >= 0 {
+		return a
+	}
+	return b
+}
+
+// compareSemanticVersions compares two semantic versions
+// Returns: -1 if a < b, 0 if a == b, 1 if a > b
+func compareSemanticVersions(a, b *semver.SemVer) int {
+	if a.Major != b.Major {
+		if a.Major < b.Major {
+			return -1
+		}
+		return 1
+	}
+	if a.Minor != b.Minor {
+		if a.Minor < b.Minor {
+			return -1
+		}
+		return 1
+	}
+	if a.Patch != b.Patch {
+		if a.Patch < b.Patch {
+			return -1
+		}
+		return 1
+	}
+	return 0
 }
 
 type emptyProvider struct{}

--- a/pkg/capabilities/merging_provider_test.go
+++ b/pkg/capabilities/merging_provider_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
+	"github.com/bazelbuild/remote-apis/build/bazel/semver"
 	"github.com/buildbarn/bb-storage/internal/mock"
 	"github.com/buildbarn/bb-storage/pkg/capabilities"
 	"github.com/buildbarn/bb-storage/pkg/digest"
@@ -224,4 +225,489 @@ func TestMergingProviderWithCompression(t *testing.T) {
 			},
 		},
 	}, serverCapabilities)
+}
+
+func TestMergingProviderAPIVersionIntersection(t *testing.T) {
+	ctrl, ctx := gomock.WithContext(context.Background(), t)
+
+	t.Run("NoProvidersWithAPIVersions", func(t *testing.T) {
+		// When no providers declare API versions, the result should not have API versions
+		// (server.go will set defaults)
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Should merge capabilities but not set API versions
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("SingleProviderWithAPIVersions", func(t *testing.T) {
+		// When only one provider declares API versions, use those versions
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+			HighApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("MultipleProvidersWithOverlappingVersions", func(t *testing.T) {
+		// Test normal intersection: provider1 supports 2.0-2.2, provider2 supports 2.1-2.3
+		// Result should be intersection: 2.1-2.2
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 1},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 3},
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			LowApiVersion:  &semver.SemVer{Major: 2, Minor: 1}, // MAX of (2.0, 2.1)
+			HighApiVersion: &semver.SemVer{Major: 2, Minor: 2}, // MIN of (2.2, 2.3)
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("API20OnlyProvider", func(t *testing.T) {
+		// Test case for API 2.0 only provider (like the real-world scenario)
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		// Provider that only supports API 2.0
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 0},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		// Provider that supports broader range
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 3},
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Result should be intersection: 2.0-2.0 (only API 2.0 supported)
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+			HighApiVersion: &semver.SemVer{Major: 2, Minor: 0},
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("NoOverlappingVersions", func(t *testing.T) {
+		// When providers have no overlapping version ranges, fall back to no API versions
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		// Provider supports 2.0-2.1
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 1},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		// Provider supports 2.2-2.3 (no overlap)
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 2},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 3},
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Should merge capabilities but not set API versions due to no overlap
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("MixedScenario", func(t *testing.T) {
+		// Mixed scenario: some providers declare versions, others don't
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider3 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2, provider3})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		// Provider with API versions
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 0},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		// Provider without API versions
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		// Another provider with API versions
+		provider3.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:  &semver.SemVer{Major: 2, Minor: 1},
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 3},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					MaxBatchTotalSizeBytes: 1024,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Should intersect only providers with versions (2.0-2.2 ∩ 2.1-2.3 = 2.1-2.2)
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			LowApiVersion:  &semver.SemVer{Major: 2, Minor: 1},
+			HighApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+				MaxBatchTotalSizeBytes: 1024,
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("PartialAPIVersions", func(t *testing.T) {
+		// Test providers with only LowApiVersion or only HighApiVersion
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		// Provider with only LowApiVersion
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion: &semver.SemVer{Major: 2, Minor: 1},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		// Provider with only HighApiVersion
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				HighApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Should handle partial API versions correctly
+		// Provider 1: only low=2.1 -> effective range 2.1-Inf (at least 2.1)
+		// Provider 2: only high=2.2 -> effective range -Inf-2.2 (up to 2.2)
+		// Intersection: 2.1-2.2
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			LowApiVersion:  &semver.SemVer{Major: 2, Minor: 1},
+			HighApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("DeprecatedApiVersionHandling", func(t *testing.T) {
+		// Test DeprecatedApiVersion handling - should take the maximum value
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider3 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2, provider3})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		// Provider with DeprecatedApiVersion 2.0
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				DeprecatedApiVersion: &semver.SemVer{Major: 2, Minor: 0},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		// Provider without DeprecatedApiVersion
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		// Provider with higher DeprecatedApiVersion 2.2 (should be the max)
+		provider3.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				DeprecatedApiVersion: &semver.SemVer{Major: 2, Minor: 2},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					MaxBatchTotalSizeBytes: 1024,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Should use the maximum DeprecatedApiVersion (2.2)
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			DeprecatedApiVersion: &semver.SemVer{Major: 2, Minor: 2}, // MAX of (2.0, nil, 2.2)
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+				MaxBatchTotalSizeBytes: 1024,
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("DeprecatedApiVersionWithAPIVersions", func(t *testing.T) {
+		// Test DeprecatedApiVersion handling combined with API version intersection
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		// Provider with both API versions and DeprecatedApiVersion
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:        &semver.SemVer{Major: 2, Minor: 0},
+				HighApiVersion:       &semver.SemVer{Major: 2, Minor: 2},
+				DeprecatedApiVersion: &semver.SemVer{Major: 1, Minor: 5},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		// Provider with different API versions and higher DeprecatedApiVersion
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				LowApiVersion:        &semver.SemVer{Major: 2, Minor: 1},
+				HighApiVersion:       &semver.SemVer{Major: 2, Minor: 3},
+				DeprecatedApiVersion: &semver.SemVer{Major: 1, Minor: 8},
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Should intersect API versions (2.1-2.2) and use max DeprecatedApiVersion (1.8)
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			LowApiVersion:        &semver.SemVer{Major: 2, Minor: 1}, // MAX of (2.0, 2.1)
+			HighApiVersion:       &semver.SemVer{Major: 2, Minor: 2}, // MIN of (2.2, 2.3)
+			DeprecatedApiVersion: &semver.SemVer{Major: 1, Minor: 8}, // MAX of (1.5, 1.8)
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
+
+	t.Run("OnlyDeprecatedApiVersion", func(t *testing.T) {
+		// Test when only one provider has DeprecatedApiVersion
+		provider1 := mock.NewMockCapabilitiesProvider(ctrl)
+		provider2 := mock.NewMockCapabilitiesProvider(ctrl)
+
+		provider := capabilities.NewMergingProvider([]capabilities.Provider{provider1, provider2})
+		instanceName := util.Must(digest.NewInstanceName("example"))
+
+		// Provider with only DeprecatedApiVersion
+		provider1.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				DeprecatedApiVersion: &semver.SemVer{Major: 1, Minor: 9},
+				CacheCapabilities: &remoteexecution.CacheCapabilities{
+					DigestFunctions: []remoteexecution.DigestFunction_Value{
+						remoteexecution.DigestFunction_SHA256,
+					},
+				},
+			}, nil)
+
+		// Provider without any API version info
+		provider2.EXPECT().GetCapabilities(gomock.Any(), instanceName).
+			Return(&remoteexecution.ServerCapabilities{
+				ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+					ExecEnabled: true,
+				},
+			}, nil)
+
+		serverCapabilities, err := provider.GetCapabilities(ctx, instanceName)
+		require.NoError(t, err)
+
+		// Should preserve the single DeprecatedApiVersion value
+		testutil.RequireEqualProto(t, &remoteexecution.ServerCapabilities{
+			DeprecatedApiVersion: &semver.SemVer{Major: 1, Minor: 9},
+			CacheCapabilities: &remoteexecution.CacheCapabilities{
+				DigestFunctions: []remoteexecution.DigestFunction_Value{
+					remoteexecution.DigestFunction_SHA256,
+				},
+			},
+			ExecutionCapabilities: &remoteexecution.ExecutionCapabilities{
+				ExecEnabled: true,
+			},
+		}, serverCapabilities)
+	})
 }


### PR DESCRIPTION
bb_clientd was hardcoded to report API version 2.3 regardless of upstream provider capabilities, causing Bazel 8+ compatibility issues when proxying to servers limited to older API versions (like 2.0).

This change implements proper API version intersection logic in MergingProvider to negotiate the highest mutually supported version between upstream providers.

Particularly relevant for Bazel 8+, which uses output_files vs output_paths based on reported server version.