### PR TITLE
Fix file refreshing in jmespath expressions

### DIFF
--- a/internal/mock/BUILD.bazel
+++ b/internal/mock/BUILD.bazel
@@ -167,6 +167,7 @@ gomock(
     out = "clock.go",
     interfaces = [
         "Clock",
+        "Ticker",
         "Timer",
     ],
     library = "//pkg/clock",

--- a/pkg/clock/clock.go
+++ b/pkg/clock/clock.go
@@ -21,10 +21,20 @@ type Clock interface {
 	// returns the channel directly to allow Timer to be an
 	// interface.
 	NewTimer(d time.Duration) (Timer, <-chan time.Time)
+
+	// Create a channel that will publish the time of day at a regular
+	// interval.
+	NewTicker(d time.Duration) (Ticker, <-chan time.Time)
 }
 
 // Timer is an interface around time.Timer. It has been added to aid
 // unit testing.
 type Timer interface {
 	Stop() bool
+}
+
+// Ticker is an interface around time.Ticker. It has been added to aid
+// unit testing.
+type Ticker interface {
+	Stop()
 }

--- a/pkg/clock/system_clock.go
+++ b/pkg/clock/system_clock.go
@@ -20,6 +20,11 @@ func (c systemClock) NewTimer(d time.Duration) (Timer, <-chan time.Time) {
 	return t, t.C
 }
 
+func (c systemClock) NewTicker(d time.Duration) (Ticker, <-chan time.Time) {
+	t := time.NewTicker(d)
+	return t, t.C
+}
+
 // SystemClock is a Clock that corresponds to the current time of day,
 // as reported by the operating system.
 var SystemClock Clock = systemClock{}

--- a/pkg/jmespath/expression.go
+++ b/pkg/jmespath/expression.go
@@ -142,8 +142,8 @@ func (e *Expression) initialiseFiles(files []*pb.File, group program.Group, cloc
 	}
 	e.currentFiles.Store(&initial)
 	group.Go(func(ctx context.Context, siblingsGroup, dependenciesGroup program.Group) error {
-		timer, t := clock.NewTimer(60 * time.Second)
-		defer timer.Stop()
+		ticker, t := clock.NewTicker(60 * time.Second)
+		defer ticker.Stop()
 		for {
 			select {
 			case <-t:


### PR DESCRIPTION
NewTimer will only fire the timer once; what was actually intended was NewTicker. This change adds a Ticker abstraction to the clock package, and then uses that instead of a timer.