### PR TITLE
Improve pretty printing of Windows-style paths

### DIFF
--- a/pkg/filesystem/BUILD.bazel
+++ b/pkg/filesystem/BUILD.bazel
@@ -71,6 +71,9 @@ go_test(
         "@rules_go//go/platform:ios": [
             "local_directory_darwin_test.go",
         ],
+        "@rules_go//go/platform:windows": [
+            "local_directory_windows_test.go",
+        ],
         "//conditions:default": [],
     }),
     deps = [

--- a/pkg/filesystem/local_directory_windows_test.go
+++ b/pkg/filesystem/local_directory_windows_test.go
@@ -1,0 +1,131 @@
+//go:build windows
+// +build windows
+
+package filesystem_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/buildbarn/bb-storage/pkg/filesystem"
+	"github.com/buildbarn/bb-storage/pkg/filesystem/path"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalDirectorySymlinkWindowsRelative(t *testing.T) {
+	// Test symlinks to targets with WindowsPathKindRelative.
+
+	tempDir := t.TempDir()
+	d, err := filesystem.NewLocalDirectory(path.LocalFormat.NewParser(tempDir))
+	require.NoError(t, err)
+
+	// Check WindowsPathKind.
+	targetPath, scopeWalker := path.EmptyBuilder.Join(path.VoidScopeWalker)
+	require.NoError(t, path.Resolve(path.WindowsFormat.NewParser("target_file"), scopeWalker))
+	require.Equal(t, path.WindowsPathKindRelative, targetPath.WindowsPathKind())
+
+	// Create symlink targets.
+	f, err := d.OpenWrite(path.MustNewComponent("target_file"), filesystem.CreateExcl(0o666))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+	require.NoError(t, d.Mkdir(path.MustNewComponent("target_dir"), 0o777))
+
+	// Create symlinks.
+	require.NoError(t, d.Symlink(path.WindowsFormat.NewParser("target_file"), path.MustNewComponent("symlink_to_file")))
+	require.NoError(t, d.Symlink(path.WindowsFormat.NewParser("target_dir"), path.MustNewComponent("symlink_to_dir")))
+
+	// Verify symlinks.
+	fi, err := d.Lstat(path.MustNewComponent("symlink_to_file"))
+	require.NoError(t, err)
+	require.Equal(t, filesystem.FileTypeSymlink, fi.Type())
+	fi, err = d.Lstat(path.MustNewComponent("symlink_to_dir"))
+	require.NoError(t, err)
+	require.Equal(t, filesystem.FileTypeSymlink, fi.Type())
+
+	// Verify symlinks can be read using standard Go filesystem routines.
+	target, err := os.Readlink(filepath.Join(tempDir, "symlink_to_file"))
+	require.NoError(t, err)
+	require.Equal(t, "target_file", target)
+
+	require.NoError(t, d.Close())
+}
+
+func TestLocalDirectorySymlinkWindowsAbsolute(t *testing.T) {
+	// Test symlinks to targets with WindowsPathKindAbsolute.
+	tempDir := t.TempDir()
+	d, err := filesystem.NewLocalDirectory(path.LocalFormat.NewParser(tempDir))
+	require.NoError(t, err)
+
+	targetDirName := "absolute_target"
+
+	// Validate WindowsPathKind.
+	targetDirPath := filepath.Join(tempDir, targetDirName)
+	builder, scopeWalker := path.EmptyBuilder.Join(path.VoidScopeWalker)
+	require.NoError(t, path.Resolve(path.WindowsFormat.NewParser(targetDirPath), scopeWalker))
+	require.Equal(t, path.WindowsPathKindAbsolute, builder.WindowsPathKind())
+	resolved, err := builder.GetWindowsString(path.WindowsPathFormatDevicePath)
+	require.NoError(t, err)
+	require.Equal(t, `\??\`+targetDirPath, resolved)
+
+	// Create symlink targets and symlinks.
+	require.NoError(t, d.Mkdir(path.MustNewComponent(targetDirName), 0o777))
+	require.NoError(t, d.Symlink(path.WindowsFormat.NewParser(targetDirPath), path.MustNewComponent("symlink_to_absolute")))
+
+	// Verify the symlink.
+	fi, err := d.Lstat(path.MustNewComponent("symlink_to_absolute"))
+	require.NoError(t, err)
+	require.Equal(t, filesystem.FileTypeSymlink, fi.Type())
+	targetParser, err := d.Readlink(path.MustNewComponent("symlink_to_absolute"))
+	require.NoError(t, err)
+	targetPath, scopeWalker := path.EmptyBuilder.Join(path.VoidScopeWalker)
+	require.NoError(t, path.Resolve(targetParser, scopeWalker))
+	targetString, err := targetPath.GetWindowsString(path.WindowsPathFormatStandard)
+	require.NoError(t, err)
+	require.Equal(t, targetDirPath, targetString)
+
+	// Verify symlink can be read using standard Go filesystem routines.
+	target, err := os.Readlink(filepath.Join(tempDir, "symlink_to_absolute"))
+	require.NoError(t, err)
+	require.Equal(t, targetDirPath, target)
+
+	require.NoError(t, d.Close())
+}
+
+func TestLocalDirectorySymlinkWindowsDriveRelative(t *testing.T) {
+	// Test symlinks to targets with WindowsPathKindDriveRelative.
+	tmpDir := t.TempDir()
+	d, err := filesystem.NewLocalDirectory(path.LocalFormat.NewParser(tmpDir))
+	require.NoError(t, err)
+
+	// Chop the drive letter off.
+	driveRelativePath := tmpDir[2:]
+
+	// Validate WindowsPathKind for drive-relative path.
+	targetPath, scopeWalker := path.EmptyBuilder.Join(path.VoidScopeWalker)
+	require.NoError(t, path.Resolve(path.WindowsFormat.NewParser(driveRelativePath), scopeWalker))
+	require.Equal(t, path.WindowsPathKindDriveRelative, targetPath.WindowsPathKind())
+
+	// Create symlink.
+	require.NoError(t, d.Symlink(path.WindowsFormat.NewParser(driveRelativePath), path.MustNewComponent("symlink_drive_relative")))
+
+	fi, err := d.Lstat(path.MustNewComponent("symlink_drive_relative"))
+	require.NoError(t, err)
+	require.Equal(t, filesystem.FileTypeSymlink, fi.Type())
+
+	// Validate the symlink target.
+	targetParser, err := d.Readlink(path.MustNewComponent("symlink_drive_relative"))
+	require.NoError(t, err)
+	targetPath, scopeWalker = path.EmptyBuilder.Join(path.VoidScopeWalker)
+	require.NoError(t, path.Resolve(targetParser, scopeWalker))
+	targetString, err := targetPath.GetWindowsString(path.WindowsPathFormatStandard)
+	require.NoError(t, err)
+	require.Equal(t, driveRelativePath, targetString)
+
+	// Verify symlink can be read using standard Go filesystem routines.
+	target, err := os.Readlink(filepath.Join(tmpDir, "symlink_drive_relative"))
+	require.NoError(t, err)
+	require.Equal(t, driveRelativePath, target)
+
+	require.NoError(t, d.Close())
+}

--- a/pkg/filesystem/path/stringer.go
+++ b/pkg/filesystem/path/stringer.go
@@ -1,8 +1,20 @@
 package path
 
+// WindowsPathFormat represents different format options for Windows path strings.
+type WindowsPathFormat int
+
+const (
+	// WindowsPathFormatStandard represents the standard Windows path format.
+	WindowsPathFormatStandard WindowsPathFormat = iota
+	// WindowsPathFormatDevicePath represents a Windows NT device path format.
+	// Note that not all paths can be printed like this (e.g. relative paths
+	// cannot), so this will fallback to WindowsPathFormatStandard.
+	WindowsPathFormatDevicePath
+)
+
 // Stringer is implemented by path types in this package that can be
 // converted to string representations.
 type Stringer interface {
 	GetUNIXString() string
-	GetWindowsString() (string, error)
+	GetWindowsString(format WindowsPathFormat) (string, error)
 }

--- a/pkg/filesystem/path/trace.go
+++ b/pkg/filesystem/path/trace.go
@@ -49,7 +49,7 @@ func (t *Trace) GetUNIXString() string {
 
 // GetWindowsString returns a string representation of the path for use
 // on Windows.
-func (t *Trace) GetWindowsString() (string, error) {
+func (t *Trace) GetWindowsString(format WindowsPathFormat) (string, error) {
 	if t == nil {
 		return ".", nil
 	}

--- a/pkg/filesystem/path/trace_test.go
+++ b/pkg/filesystem/path/trace_test.go
@@ -29,15 +29,19 @@ func TestTrace(t *testing.T) {
 	t.Run("WindowsUNIXLikeIdentity", func(t *testing.T) {
 		var p1 *path.Trace
 		require.Equal(t, ".", mustGetWindowsString(p1))
+		require.Equal(t, ".", mustGetWindowsDevicePathString(p1))
 
 		p2 := p1.Append(path.MustNewComponent("a"))
 		require.Equal(t, "a", mustGetWindowsString(p2))
+		require.Equal(t, "a", mustGetWindowsDevicePathString(p2))
 
 		p3 := p2.Append(path.MustNewComponent("b"))
 		require.Equal(t, "a\\b", mustGetWindowsString(p3))
+		require.Equal(t, "a\\b", mustGetWindowsDevicePathString(p3))
 
 		p4 := p3.Append(path.MustNewComponent("c"))
 		require.Equal(t, "a\\b\\c", mustGetWindowsString(p4))
+		require.Equal(t, "a\\b\\c", mustGetWindowsDevicePathString(p4))
 	})
 
 	t.Run("WindowsPathValidation", func(t *testing.T) {
@@ -48,14 +52,14 @@ func TestTrace(t *testing.T) {
 			p2 := p1.Append(path.MustNewComponent("a:"))
 			p3 := p2.Append(path.MustNewComponent("b"))
 
-			_, err := p3.GetWindowsString()
+			_, err := p3.GetWindowsString(path.WindowsPathFormatStandard)
 			testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Invalid pathname component \"a:\": Pathname component contains reserved characters"), err)
 		}
 		{
 			var p1 *path.Trace
 			require.Equal(t, ".", mustGetWindowsString(p1))
 			p2 := p1.Append(path.MustNewComponent("b?"))
-			_, err := p2.GetWindowsString()
+			_, err := p2.GetWindowsString(path.WindowsPathFormatStandard)
 			testutil.RequireEqualStatus(t, status.Error(codes.InvalidArgument, "Invalid pathname component \"b?\": Pathname component contains reserved characters"), err)
 		}
 	})

--- a/pkg/filesystem/path/windows_format.go
+++ b/pkg/filesystem/path/windows_format.go
@@ -16,7 +16,7 @@ func (windowsFormat) NewParser(path string) Parser {
 }
 
 func (windowsFormat) GetString(s Stringer) (string, error) {
-	return s.GetWindowsString()
+	return s.GetWindowsString(WindowsPathFormatStandard)
 }
 
 // WindowsFormat is capable of parsing Windows-style pathname strings, and


### PR DESCRIPTION
This provides a neater way of constructing NT device paths which are required for some system calls (e.g. creation of symlinks).