### PR TITLE
Make graceful shutdown work on Windows.

### DIFF
--- a/pkg/program/run_main.go
+++ b/pkg/program/run_main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -63,6 +64,12 @@ func RunMain(routine Routine) {
 		receivedSignal := <-signalChan
 		log.Printf("Received %#v signal. Initiating graceful shutdown.", receivedSignal.String())
 		errorLogger.startShutdown(func() {
+			if runtime.GOOS == "windows" {
+				// On Windows, process.Signal() is not supported so
+				// immediately exit.
+				os.Exit(1)
+			}
+
 			// Clear the signal handler and raise the
 			// original signal once again. That way we shut
 			// down under the original circumstances.


### PR DESCRIPTION
Prior to this, sending ctrl+c (which is also sent by k8s) to a buildbarn process would result in the following message:

    2025/08/21 08:03:48 Received "interrupt" signal. Initiating graceful shutdown.
    panic: not supported by windows

    goroutine 1 [running]:
    github.com/buildbarn/bb-storage/pkg/program.RunMain.func1.1()
            pkg/program/run_main.go:75 +0x94
    github.com/buildbarn/bb-storage/pkg/program.RunMain(0x1e48f68)
            pkg/program/run_main.go:105 +0x167
    main.main()
            cmd/bb_storage/main.go:31 +0x1a

This is because process.Signal only supports sending SIGKILL on Windows.