### PR TITLE
Handle relative paths when creating dirs or block devices on Windows

### DIFF
--- a/pkg/blockdevice/new_block_device_from_file_test.go
+++ b/pkg/blockdevice/new_block_device_from_file_test.go
@@ -122,3 +122,22 @@ func TestNewBlockDeviceFromFileZeroInitialize(t *testing.T) {
 
 	require.NoError(t, blockDevice.Close())
 }
+
+func TestNewBlockDeviceFromFileRelativePath(t *testing.T) {
+	// Check that we can open block devices with relative file paths.
+	tempDir := t.TempDir()
+
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+
+	blockDevicePath := "bd_relative"
+	blockDevice, _, _, err := blockdevice.NewBlockDeviceFromFile(blockDevicePath, 8, false)
+	require.NoError(t, err)
+	require.NoError(t, blockDevice.Close())
+
+	_, err = os.Stat(filepath.Join(tempDir, blockDevicePath))
+	require.NoError(t, err)
+
+	require.NoError(t, os.Chdir(originalWd))
+}

--- a/pkg/blockdevice/new_block_device_from_file_windows.go
+++ b/pkg/blockdevice/new_block_device_from_file_windows.go
@@ -5,6 +5,7 @@ package blockdevice
 
 import (
 	"fmt"
+	"path/filepath"
 	"syscall"
 	"unsafe"
 
@@ -24,6 +25,10 @@ var (
 // NewBlockDeviceFromFile creates a BlockDevice that is backed by a
 // regular file stored in a file system.
 func NewBlockDeviceFromFile(path string, minimumSizeBytes int, zeroInitialize bool) (BlockDevice, int, int64, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return nil, 0, 0, util.StatusWrapf(err, "Failed to get absolute path for %#v", path)
+	}
 	pathPtr, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, 0, 0, util.StatusWrapf(err, "Failed to convert path %#v to UTF-16", path)

--- a/pkg/filesystem/local_directory_test.go
+++ b/pkg/filesystem/local_directory_test.go
@@ -3,6 +3,7 @@ package filesystem_test
 import (
 	"io"
 	"os"
+	"path/filepath"
 	"runtime"
 	"syscall"
 	"testing"
@@ -536,6 +537,25 @@ func TestLocalDirectoryIsWritableChild(t *testing.T) {
 		require.NoError(t, err)
 		require.False(t, isWritable, "Want file not to be writable")
 	}
+}
+
+func TestLocalDirectoryNewLocalDirectoryRelativePath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	subdir := "test_subdir"
+	subdirPath := filepath.Join(tempDir, subdir)
+	require.NoError(t, os.Mkdir(subdirPath, 0o755))
+
+	// Save the current working directory so we can restore it.
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+
+	d, err := filesystem.NewLocalDirectory(path.LocalFormat.NewParser(subdir))
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	require.NoError(t, os.Chdir(originalWd))
 }
 
 func writeFile(t *testing.T, directory filesystem.Directory, name string, permissions os.FileMode) {

--- a/pkg/filesystem/local_directory_windows_test.go
+++ b/pkg/filesystem/local_directory_windows_test.go
@@ -129,3 +129,23 @@ func TestLocalDirectorySymlinkWindowsDriveRelative(t *testing.T) {
 
 	require.NoError(t, d.Close())
 }
+
+func TestLocalDirectoryNewLocalDirectoryDriveRelativePath(t *testing.T) {
+	tempDir := t.TempDir()
+
+	subdir := "test_subdir"
+	subdirPath := filepath.Join(tempDir, subdir)
+	require.NoError(t, os.Mkdir(subdirPath, 0o755))
+
+	// Save the current working directory so we can restore it.
+	originalWd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(tempDir))
+
+	// Test NewLocalDirectory with a drive-relative path.
+	d, err := filesystem.NewLocalDirectory(path.LocalFormat.NewParser(subdirPath[2:]))
+	require.NoError(t, err)
+	require.NoError(t, d.Close())
+
+	require.NoError(t, os.Chdir(originalWd))
+}


### PR DESCRIPTION
On Linux, buildbarn allows relative paths in the configuration, whereas on Windows some paths were required to be absolute. This was found whilst writing an integration test for buildbarn on Windows.