### PR TITLE
Fix test vector comparison

### DIFF
--- a/pkg/jmespath/BUILD.bazel
+++ b/pkg/jmespath/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "@com_github_jmespath_go_jmespath//:go-jmespath",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//proto",
         "@org_golang_google_protobuf//types/known/structpb",
     ],
 )
@@ -31,6 +32,7 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
+        "@org_golang_google_protobuf//encoding/protojson",
         "@org_golang_google_protobuf//types/known/structpb",
         "@org_uber_go_mock//gomock",
     ],

--- a/pkg/jmespath/expression.go
+++ b/pkg/jmespath/expression.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"maps"
 	"os"
-	"reflect"
 	"sync/atomic"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -124,7 +124,7 @@ func (e *Expression) checkTestVector(t *pb.TestVector) error {
 		return util.StatusWrapf(err, "Failed to convert JMESPath result to protobuf value")
 	}
 
-	if !reflect.DeepEqual(t.ExpectedOutput, actualPb) {
+	if !proto.Equal(actualPb, t.ExpectedOutput) {
 		expectedJSON, _ := json.Marshal(t.ExpectedOutput)
 		actualJSON, _ := json.Marshal(actual)
 		return status.Errorf(codes.InvalidArgument, "Test vector failed: expected %s, got %s", string(expectedJSON), string(actualJSON))


### PR DESCRIPTION
It seems that using reflect.DeepEqual on protobuf messages doesn't work correctly; seemingly equal things are different because of internal protobuf fields.

This switches the comparison to use the protocmp library which does proper equality comparison. I've also extended the test cases to cover this.