### PR TITLE
Start using gazelle:proto_import_prefix

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,6 +4,7 @@ load("@gazelle//:def.bzl", "gazelle")
 
 # gazelle:go_grpc_compilers @rules_go//proto:go_proto,@rules_go//proto:go_grpc_v2
 # gazelle:prefix github.com/buildbarn/bb-storage
+# gazelle:proto_import_prefix github.com/buildbarn/bb-storage
 # gazelle:resolve go github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2 @bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_go_proto
 # gazelle:resolve go github.com/bazelbuild/remote-apis/build/bazel/semver @bazel_remote_apis//build/bazel/semver:semver_go_proto
 # gazelle:resolve go github.com/google/go-jsonnet @jsonnet_go//:go_default_library

--- a/pkg/proto/auth/BUILD.bazel
+++ b/pkg/proto/auth/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "auth_proto",
     srcs = ["auth.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "@opentelemetry-proto//:common_proto",

--- a/pkg/proto/auth/auth.pb.go
+++ b/pkg/proto/auth/auth.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/auth/auth.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto
 
 package auth
 
@@ -36,7 +36,7 @@ type AuthenticationMetadata struct {
 
 func (x *AuthenticationMetadata) Reset() {
 	*x = AuthenticationMetadata{}
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -48,7 +48,7 @@ func (x *AuthenticationMetadata) String() string {
 func (*AuthenticationMetadata) ProtoMessage() {}
 
 func (x *AuthenticationMetadata) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61,7 +61,7 @@ func (x *AuthenticationMetadata) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticationMetadata.ProtoReflect.Descriptor instead.
 func (*AuthenticationMetadata) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *AuthenticationMetadata) GetPublic() *structpb.Value {
@@ -95,7 +95,7 @@ type AuthenticateRequest struct {
 
 func (x *AuthenticateRequest) Reset() {
 	*x = AuthenticateRequest{}
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -107,7 +107,7 @@ func (x *AuthenticateRequest) String() string {
 func (*AuthenticateRequest) ProtoMessage() {}
 
 func (x *AuthenticateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -120,7 +120,7 @@ func (x *AuthenticateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticateRequest.ProtoReflect.Descriptor instead.
 func (*AuthenticateRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *AuthenticateRequest) GetRequestMetadata() map[string]*AuthenticateRequest_ValueList {
@@ -151,7 +151,7 @@ type AuthenticateResponse struct {
 
 func (x *AuthenticateResponse) Reset() {
 	*x = AuthenticateResponse{}
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -163,7 +163,7 @@ func (x *AuthenticateResponse) String() string {
 func (*AuthenticateResponse) ProtoMessage() {}
 
 func (x *AuthenticateResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -176,7 +176,7 @@ func (x *AuthenticateResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticateResponse.ProtoReflect.Descriptor instead.
 func (*AuthenticateResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *AuthenticateResponse) GetVerdict() isAuthenticateResponse_Verdict {
@@ -238,7 +238,7 @@ type AuthorizeRequest struct {
 
 func (x *AuthorizeRequest) Reset() {
 	*x = AuthorizeRequest{}
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -250,7 +250,7 @@ func (x *AuthorizeRequest) String() string {
 func (*AuthorizeRequest) ProtoMessage() {}
 
 func (x *AuthorizeRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -263,7 +263,7 @@ func (x *AuthorizeRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeRequest.ProtoReflect.Descriptor instead.
 func (*AuthorizeRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{3}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *AuthorizeRequest) GetAuthenticationMetadata() *AuthenticationMetadata {
@@ -301,7 +301,7 @@ type AuthorizeResponse struct {
 
 func (x *AuthorizeResponse) Reset() {
 	*x = AuthorizeResponse{}
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -313,7 +313,7 @@ func (x *AuthorizeResponse) String() string {
 func (*AuthorizeResponse) ProtoMessage() {}
 
 func (x *AuthorizeResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -326,7 +326,7 @@ func (x *AuthorizeResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizeResponse.ProtoReflect.Descriptor instead.
 func (*AuthorizeResponse) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{4}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *AuthorizeResponse) GetVerdict() isAuthorizeResponse_Verdict {
@@ -386,7 +386,7 @@ type AuthenticateRequest_ValueList struct {
 
 func (x *AuthenticateRequest_ValueList) Reset() {
 	*x = AuthenticateRequest_ValueList{}
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -398,7 +398,7 @@ func (x *AuthenticateRequest_ValueList) String() string {
 func (*AuthenticateRequest_ValueList) ProtoMessage() {}
 
 func (x *AuthenticateRequest_ValueList) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_auth_auth_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -411,7 +411,7 @@ func (x *AuthenticateRequest_ValueList) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticateRequest_ValueList.ProtoReflect.Descriptor instead.
 func (*AuthenticateRequest_ValueList) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{1, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescGZIP(), []int{1, 0}
 }
 
 func (x *AuthenticateRequest_ValueList) GetValue() []string {
@@ -421,11 +421,11 @@ func (x *AuthenticateRequest_ValueList) GetValue() []string {
 	return nil
 }
 
-var File_pkg_proto_auth_auth_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_auth_auth_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDesc = "" +
 	"\n" +
-	"\x19pkg/proto/auth/auth.proto\x12\x0ebuildbarn.auth\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a*opentelemetry/proto/common/v1/common.proto\"\xd2\x01\n" +
+	"9github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto\x12\x0ebuildbarn.auth\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a*opentelemetry/proto/common/v1/common.proto\"\xd2\x01\n" +
 	"\x16AuthenticationMetadata\x12.\n" +
 	"\x06public\x18\x01 \x01(\v2\x16.google.protobuf.ValueR\x06public\x12V\n" +
 	"\x12tracing_attributes\x18\x02 \x03(\v2'.opentelemetry.proto.common.v1.KeyValueR\x11tracingAttributes\x120\n" +
@@ -459,19 +459,19 @@ const file_pkg_proto_auth_auth_proto_rawDesc = "" +
 	"\tAuthorize\x12 .buildbarn.auth.AuthorizeRequest\x1a!.buildbarn.auth.AuthorizeResponse\"\x00B0Z.github.com/buildbarn/bb-storage/pkg/proto/authb\x06proto3"
 
 var (
-	file_pkg_proto_auth_auth_proto_rawDescOnce sync.Once
-	file_pkg_proto_auth_auth_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescData []byte
 )
 
-func file_pkg_proto_auth_auth_proto_rawDescGZIP() []byte {
-	file_pkg_proto_auth_auth_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_auth_auth_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_auth_auth_proto_rawDesc), len(file_pkg_proto_auth_auth_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDesc)))
 	})
-	return file_pkg_proto_auth_auth_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDescData
 }
 
-var file_pkg_proto_auth_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
-var file_pkg_proto_auth_auth_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_goTypes = []any{
 	(*AuthenticationMetadata)(nil),        // 0: buildbarn.auth.AuthenticationMetadata
 	(*AuthenticateRequest)(nil),           // 1: buildbarn.auth.AuthenticateRequest
 	(*AuthenticateResponse)(nil),          // 2: buildbarn.auth.AuthenticateResponse
@@ -484,7 +484,7 @@ var file_pkg_proto_auth_auth_proto_goTypes = []any{
 	(*timestamppb.Timestamp)(nil),         // 9: google.protobuf.Timestamp
 	(*emptypb.Empty)(nil),                 // 10: google.protobuf.Empty
 }
-var file_pkg_proto_auth_auth_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_depIdxs = []int32{
 	7,  // 0: buildbarn.auth.AuthenticationMetadata.public:type_name -> google.protobuf.Value
 	8,  // 1: buildbarn.auth.AuthenticationMetadata.tracing_attributes:type_name -> opentelemetry.proto.common.v1.KeyValue
 	7,  // 2: buildbarn.auth.AuthenticationMetadata.private:type_name -> google.protobuf.Value
@@ -508,16 +508,16 @@ var file_pkg_proto_auth_auth_proto_depIdxs = []int32{
 	0,  // [0:12] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_auth_auth_proto_init() }
-func file_pkg_proto_auth_auth_proto_init() {
-	if File_pkg_proto_auth_auth_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto != nil {
 		return
 	}
-	file_pkg_proto_auth_auth_proto_msgTypes[2].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[2].OneofWrappers = []any{
 		(*AuthenticateResponse_Allow)(nil),
 		(*AuthenticateResponse_Deny)(nil),
 	}
-	file_pkg_proto_auth_auth_proto_msgTypes[4].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes[4].OneofWrappers = []any{
 		(*AuthorizeResponse_Allow)(nil),
 		(*AuthorizeResponse_Deny)(nil),
 	}
@@ -525,17 +525,17 @@ func file_pkg_proto_auth_auth_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_auth_auth_proto_rawDesc), len(file_pkg_proto_auth_auth_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   2,
 		},
-		GoTypes:           file_pkg_proto_auth_auth_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_auth_auth_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_auth_auth_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_auth_auth_proto = out.File
-	file_pkg_proto_auth_auth_proto_goTypes = nil
-	file_pkg_proto_auth_auth_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_auth_auth_proto_depIdxs = nil
 }

--- a/pkg/proto/auth/auth_grpc.pb.go
+++ b/pkg/proto/auth/auth_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.5.1
 // - protoc             v6.31.1
-// source: pkg/proto/auth/auth.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto
 
 package auth
 
@@ -115,7 +115,7 @@ var Authentication_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "pkg/proto/auth/auth.proto",
+	Metadata: "github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto",
 }
 
 const (
@@ -215,5 +215,5 @@ var Authorizer_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "pkg/proto/auth/auth.proto",
+	Metadata: "github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto",
 }

--- a/pkg/proto/blobstore/local/BUILD.bazel
+++ b/pkg/proto/blobstore/local/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "local_proto",
     srcs = ["local.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/proto/blobstore/local/local.pb.go
+++ b/pkg/proto/blobstore/local/local.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/blobstore/local/local.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/blobstore/local/local.proto
 
 package local
 
@@ -31,7 +31,7 @@ type BlockLocation struct {
 
 func (x *BlockLocation) Reset() {
 	*x = BlockLocation{}
-	mi := &file_pkg_proto_blobstore_local_local_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -43,7 +43,7 @@ func (x *BlockLocation) String() string {
 func (*BlockLocation) ProtoMessage() {}
 
 func (x *BlockLocation) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_blobstore_local_local_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56,7 +56,7 @@ func (x *BlockLocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlockLocation.ProtoReflect.Descriptor instead.
 func (*BlockLocation) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_blobstore_local_local_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *BlockLocation) GetOffsetBytes() int64 {
@@ -84,7 +84,7 @@ type BlockState struct {
 
 func (x *BlockState) Reset() {
 	*x = BlockState{}
-	mi := &file_pkg_proto_blobstore_local_local_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -96,7 +96,7 @@ func (x *BlockState) String() string {
 func (*BlockState) ProtoMessage() {}
 
 func (x *BlockState) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_blobstore_local_local_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -109,7 +109,7 @@ func (x *BlockState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlockState.ProtoReflect.Descriptor instead.
 func (*BlockState) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_blobstore_local_local_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *BlockState) GetWriteOffsetBytes() int64 {
@@ -144,7 +144,7 @@ type PersistentState struct {
 
 func (x *PersistentState) Reset() {
 	*x = PersistentState{}
-	mi := &file_pkg_proto_blobstore_local_local_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -156,7 +156,7 @@ func (x *PersistentState) String() string {
 func (*PersistentState) ProtoMessage() {}
 
 func (x *PersistentState) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_blobstore_local_local_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -169,7 +169,7 @@ func (x *PersistentState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PersistentState.ProtoReflect.Descriptor instead.
 func (*PersistentState) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_blobstore_local_local_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *PersistentState) GetOldestEpochId() uint32 {
@@ -193,11 +193,11 @@ func (x *PersistentState) GetKeyLocationMapHashInitialization() uint64 {
 	return 0
 }
 
-var File_pkg_proto_blobstore_local_local_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_blobstore_local_local_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDesc = "" +
 	"\n" +
-	"%pkg/proto/blobstore/local/local.proto\x12\x19buildbarn.blobstore.local\"Q\n" +
+	"Egithub.com/buildbarn/bb-storage/pkg/proto/blobstore/local/local.proto\x12\x19buildbarn.blobstore.local\"Q\n" +
 	"\rBlockLocation\x12!\n" +
 	"\foffset_bytes\x18\x01 \x01(\x03R\voffsetBytes\x12\x1d\n" +
 	"\n" +
@@ -213,24 +213,24 @@ const file_pkg_proto_blobstore_local_local_proto_rawDesc = "" +
 	"$key_location_map_hash_initialization\x18\x03 \x01(\x04R keyLocationMapHashInitializationB;Z9github.com/buildbarn/bb-storage/pkg/proto/blobstore/localb\x06proto3"
 
 var (
-	file_pkg_proto_blobstore_local_local_proto_rawDescOnce sync.Once
-	file_pkg_proto_blobstore_local_local_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescData []byte
 )
 
-func file_pkg_proto_blobstore_local_local_proto_rawDescGZIP() []byte {
-	file_pkg_proto_blobstore_local_local_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_blobstore_local_local_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_blobstore_local_local_proto_rawDesc), len(file_pkg_proto_blobstore_local_local_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDesc)))
 	})
-	return file_pkg_proto_blobstore_local_local_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDescData
 }
 
-var file_pkg_proto_blobstore_local_local_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_pkg_proto_blobstore_local_local_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_goTypes = []any{
 	(*BlockLocation)(nil),   // 0: buildbarn.blobstore.local.BlockLocation
 	(*BlockState)(nil),      // 1: buildbarn.blobstore.local.BlockState
 	(*PersistentState)(nil), // 2: buildbarn.blobstore.local.PersistentState
 }
-var file_pkg_proto_blobstore_local_local_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_depIdxs = []int32{
 	0, // 0: buildbarn.blobstore.local.BlockState.block_location:type_name -> buildbarn.blobstore.local.BlockLocation
 	1, // 1: buildbarn.blobstore.local.PersistentState.blocks:type_name -> buildbarn.blobstore.local.BlockState
 	2, // [2:2] is the sub-list for method output_type
@@ -240,26 +240,26 @@ var file_pkg_proto_blobstore_local_local_proto_depIdxs = []int32{
 	0, // [0:2] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_blobstore_local_local_proto_init() }
-func file_pkg_proto_blobstore_local_local_proto_init() {
-	if File_pkg_proto_blobstore_local_local_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_blobstore_local_local_proto_rawDesc), len(file_pkg_proto_blobstore_local_local_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_blobstore_local_local_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_blobstore_local_local_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_blobstore_local_local_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_blobstore_local_local_proto = out.File
-	file_pkg_proto_blobstore_local_local_proto_goTypes = nil
-	file_pkg_proto_blobstore_local_local_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_blobstore_local_local_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/auth/BUILD.bazel
+++ b/pkg/proto/configuration/auth/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "auth_proto",
     srcs = ["auth.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/eviction:eviction_proto",

--- a/pkg/proto/configuration/auth/auth.pb.go
+++ b/pkg/proto/configuration/auth/auth.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/auth/auth.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/auth/auth.proto
 
 package auth
 
@@ -42,7 +42,7 @@ type AuthorizerConfiguration struct {
 
 func (x *AuthorizerConfiguration) Reset() {
 	*x = AuthorizerConfiguration{}
-	mi := &file_pkg_proto_configuration_auth_auth_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54,7 +54,7 @@ func (x *AuthorizerConfiguration) String() string {
 func (*AuthorizerConfiguration) ProtoMessage() {}
 
 func (x *AuthorizerConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_auth_auth_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67,7 +67,7 @@ func (x *AuthorizerConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthorizerConfiguration.ProtoReflect.Descriptor instead.
 func (*AuthorizerConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_auth_auth_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *AuthorizerConfiguration) GetPolicy() isAuthorizerConfiguration_Policy {
@@ -165,7 +165,7 @@ type InstanceNameAuthorizer struct {
 
 func (x *InstanceNameAuthorizer) Reset() {
 	*x = InstanceNameAuthorizer{}
-	mi := &file_pkg_proto_configuration_auth_auth_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -177,7 +177,7 @@ func (x *InstanceNameAuthorizer) String() string {
 func (*InstanceNameAuthorizer) ProtoMessage() {}
 
 func (x *InstanceNameAuthorizer) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_auth_auth_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -190,7 +190,7 @@ func (x *InstanceNameAuthorizer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use InstanceNameAuthorizer.ProtoReflect.Descriptor instead.
 func (*InstanceNameAuthorizer) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_auth_auth_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *InstanceNameAuthorizer) GetAllowedInstanceNamePrefixes() []string {
@@ -212,7 +212,7 @@ type RemoteAuthorizer struct {
 
 func (x *RemoteAuthorizer) Reset() {
 	*x = RemoteAuthorizer{}
-	mi := &file_pkg_proto_configuration_auth_auth_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -224,7 +224,7 @@ func (x *RemoteAuthorizer) String() string {
 func (*RemoteAuthorizer) ProtoMessage() {}
 
 func (x *RemoteAuthorizer) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_auth_auth_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -237,7 +237,7 @@ func (x *RemoteAuthorizer) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoteAuthorizer.ProtoReflect.Descriptor instead.
 func (*RemoteAuthorizer) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_auth_auth_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *RemoteAuthorizer) GetEndpoint() *grpc.ClientConfiguration {
@@ -268,11 +268,11 @@ func (x *RemoteAuthorizer) GetCacheReplacementPolicy() eviction.CacheReplacement
 	return eviction.CacheReplacementPolicy(0)
 }
 
-var File_pkg_proto_configuration_auth_auth_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_auth_auth_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDesc = "" +
 	"\n" +
-	"'pkg/proto/configuration/auth/auth.proto\x12\x1cbuildbarn.configuration.auth\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\x1a/pkg/proto/configuration/jmespath/jmespath.proto\"\x96\x03\n" +
+	"Ggithub.com/buildbarn/bb-storage/pkg/proto/configuration/auth/auth.proto\x12\x1cbuildbarn.configuration.auth\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x96\x03\n" +
 	"\x17AuthorizerConfiguration\x12.\n" +
 	"\x05allow\x18\x01 \x01(\v2\x16.google.protobuf.EmptyH\x00R\x05allow\x12h\n" +
 	"\x14instance_name_prefix\x18\x02 \x01(\v24.buildbarn.configuration.auth.InstanceNameAuthorizerH\x00R\x12instanceNamePrefix\x12,\n" +
@@ -289,19 +289,19 @@ const file_pkg_proto_configuration_auth_auth_proto_rawDesc = "" +
 	"\x18cache_replacement_policy\x18\x04 \x01(\x0e28.buildbarn.configuration.eviction.CacheReplacementPolicyR\x16cacheReplacementPolicyB>Z<github.com/buildbarn/bb-storage/pkg/proto/configuration/authb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_auth_auth_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_auth_auth_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_auth_auth_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_auth_auth_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_auth_auth_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_auth_auth_proto_rawDesc), len(file_pkg_proto_configuration_auth_auth_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_auth_auth_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_auth_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_pkg_proto_configuration_auth_auth_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_goTypes = []any{
 	(*AuthorizerConfiguration)(nil),      // 0: buildbarn.configuration.auth.AuthorizerConfiguration
 	(*InstanceNameAuthorizer)(nil),       // 1: buildbarn.configuration.auth.InstanceNameAuthorizer
 	(*RemoteAuthorizer)(nil),             // 2: buildbarn.configuration.auth.RemoteAuthorizer
@@ -311,7 +311,7 @@ var file_pkg_proto_configuration_auth_auth_proto_goTypes = []any{
 	(*structpb.Value)(nil),               // 6: google.protobuf.Value
 	(eviction.CacheReplacementPolicy)(0), // 7: buildbarn.configuration.eviction.CacheReplacementPolicy
 }
-var file_pkg_proto_configuration_auth_auth_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_depIdxs = []int32{
 	3, // 0: buildbarn.configuration.auth.AuthorizerConfiguration.allow:type_name -> google.protobuf.Empty
 	1, // 1: buildbarn.configuration.auth.AuthorizerConfiguration.instance_name_prefix:type_name -> buildbarn.configuration.auth.InstanceNameAuthorizer
 	3, // 2: buildbarn.configuration.auth.AuthorizerConfiguration.deny:type_name -> google.protobuf.Empty
@@ -327,12 +327,12 @@ var file_pkg_proto_configuration_auth_auth_proto_depIdxs = []int32{
 	0, // [0:8] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_auth_auth_proto_init() }
-func file_pkg_proto_configuration_auth_auth_proto_init() {
-	if File_pkg_proto_configuration_auth_auth_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_auth_auth_proto_msgTypes[0].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes[0].OneofWrappers = []any{
 		(*AuthorizerConfiguration_Allow)(nil),
 		(*AuthorizerConfiguration_InstanceNamePrefix)(nil),
 		(*AuthorizerConfiguration_Deny)(nil),
@@ -343,17 +343,17 @@ func file_pkg_proto_configuration_auth_auth_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_auth_auth_proto_rawDesc), len(file_pkg_proto_configuration_auth_auth_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_auth_auth_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_auth_auth_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_auth_auth_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_auth_auth_proto = out.File
-	file_pkg_proto_configuration_auth_auth_proto_goTypes = nil
-	file_pkg_proto_configuration_auth_auth_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_auth_auth_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/auth/auth.proto
+++ b/pkg/proto/configuration/auth/auth.proto
@@ -2,11 +2,11 @@ syntax = "proto3";
 
 package buildbarn.configuration.auth;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
-import "pkg/proto/configuration/eviction/eviction.proto";
-import "pkg/proto/configuration/grpc/grpc.proto";
-import "pkg/proto/configuration/jmespath/jmespath.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/auth";
 

--- a/pkg/proto/configuration/bb_copy/BUILD.bazel
+++ b/pkg/proto/configuration/bb_copy/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "buildbarn_configuration_bb_copy_proto",
     srcs = ["bb_copy.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/blobstore:blobstore_proto",

--- a/pkg/proto/configuration/bb_copy/bb_copy.pb.go
+++ b/pkg/proto/configuration/bb_copy/bb_copy.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/bb_copy/bb_copy.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/bb_copy/bb_copy.proto
 
 package bb_copy
 
@@ -42,7 +42,7 @@ type ApplicationConfiguration struct {
 
 func (x *ApplicationConfiguration) Reset() {
 	*x = ApplicationConfiguration{}
-	mi := &file_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -54,7 +54,7 @@ func (x *ApplicationConfiguration) String() string {
 func (*ApplicationConfiguration) ProtoMessage() {}
 
 func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -67,7 +67,7 @@ func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplicationConfiguration.ProtoReflect.Descriptor instead.
 func (*ApplicationConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ApplicationConfiguration) GetSource() *blobstore.BlobAccessConfiguration {
@@ -147,11 +147,11 @@ func (x *ApplicationConfiguration) GetDigestFunction() v2.DigestFunction_Value {
 	return v2.DigestFunction_Value(0)
 }
 
-var File_pkg_proto_configuration_bb_copy_bb_copy_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc = "" +
 	"\n" +
-	"-pkg/proto/configuration/bb_copy/bb_copy.proto\x12\x1fbuildbarn.configuration.bb_copy\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a1pkg/proto/configuration/blobstore/blobstore.proto\"\xa1\x06\n" +
+	"Mgithub.com/buildbarn/bb-storage/pkg/proto/configuration/bb_copy/bb_copy.proto\x12\x1fbuildbarn.configuration.bb_copy\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1aQgithub.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto\"\xa1\x06\n" +
 	"\x18ApplicationConfiguration\x12R\n" +
 	"\x06source\x18\x01 \x01(\v2:.buildbarn.configuration.blobstore.BlobAccessConfigurationR\x06source\x12N\n" +
 	"\x04sink\x18\x02 \x01(\v2:.buildbarn.configuration.blobstore.BlobAccessConfigurationR\x04sink\x12^\n" +
@@ -169,26 +169,26 @@ const file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc = "" +
 	"\x0fdigest_function\x18\v \x01(\x0e25.build.bazel.remote.execution.v2.DigestFunction.ValueR\x0edigestFunctionb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc), len(file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_bb_copy_bb_copy_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_goTypes = []any{
 	(*ApplicationConfiguration)(nil),              // 0: buildbarn.configuration.bb_copy.ApplicationConfiguration
 	(*blobstore.BlobAccessConfiguration)(nil),     // 1: buildbarn.configuration.blobstore.BlobAccessConfiguration
 	(*blobstore.BlobReplicatorConfiguration)(nil), // 2: buildbarn.configuration.blobstore.BlobReplicatorConfiguration
 	(*v2.Digest)(nil),                             // 3: build.bazel.remote.execution.v2.Digest
 	(v2.DigestFunction_Value)(0),                  // 4: build.bazel.remote.execution.v2.DigestFunction.Value
 }
-var file_pkg_proto_configuration_bb_copy_bb_copy_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.bb_copy.ApplicationConfiguration.source:type_name -> buildbarn.configuration.blobstore.BlobAccessConfiguration
 	1, // 1: buildbarn.configuration.bb_copy.ApplicationConfiguration.sink:type_name -> buildbarn.configuration.blobstore.BlobAccessConfiguration
 	2, // 2: buildbarn.configuration.bb_copy.ApplicationConfiguration.replicator:type_name -> buildbarn.configuration.blobstore.BlobReplicatorConfiguration
@@ -204,26 +204,28 @@ var file_pkg_proto_configuration_bb_copy_bb_copy_proto_depIdxs = []int32{
 	0, // [0:8] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_bb_copy_bb_copy_proto_init() }
-func file_pkg_proto_configuration_bb_copy_bb_copy_proto_init() {
-	if File_pkg_proto_configuration_bb_copy_bb_copy_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc), len(file_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_bb_copy_bb_copy_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_bb_copy_bb_copy_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_bb_copy_bb_copy_proto = out.File
-	file_pkg_proto_configuration_bb_copy_bb_copy_proto_goTypes = nil
-	file_pkg_proto_configuration_bb_copy_bb_copy_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_copy_bb_copy_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/bb_copy/bb_copy.proto
+++ b/pkg/proto/configuration/bb_copy/bb_copy.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 package buildbarn.configuration.bb_copy;
 
 import "build/bazel/remote/execution/v2/remote_execution.proto";
-import "pkg/proto/configuration/blobstore/blobstore.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto";
 
 message ApplicationConfiguration {
   // Content Addressable Storage where data needs to be read.

--- a/pkg/proto/configuration/bb_replicator/BUILD.bazel
+++ b/pkg/proto/configuration/bb_replicator/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "bb_replicator_proto",
     srcs = ["bb_replicator.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/blobstore:blobstore_proto",

--- a/pkg/proto/configuration/bb_replicator/bb_replicator.pb.go
+++ b/pkg/proto/configuration/bb_replicator/bb_replicator.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/bb_replicator/bb_replicator.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/bb_replicator/bb_replicator.proto
 
 package bb_replicator
 
@@ -38,7 +38,7 @@ type ApplicationConfiguration struct {
 
 func (x *ApplicationConfiguration) Reset() {
 	*x = ApplicationConfiguration{}
-	mi := &file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -50,7 +50,7 @@ func (x *ApplicationConfiguration) String() string {
 func (*ApplicationConfiguration) ProtoMessage() {}
 
 func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -63,7 +63,7 @@ func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplicationConfiguration.ProtoReflect.Descriptor instead.
 func (*ApplicationConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ApplicationConfiguration) GetGrpcServers() []*grpc.ServerConfiguration {
@@ -108,11 +108,11 @@ func (x *ApplicationConfiguration) GetGlobal() *global.Configuration {
 	return nil
 }
 
-var File_pkg_proto_configuration_bb_replicator_bb_replicator_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc = "" +
 	"\n" +
-	"9pkg/proto/configuration/bb_replicator/bb_replicator.proto\x12%buildbarn.configuration.bb_replicator\x1a1pkg/proto/configuration/blobstore/blobstore.proto\x1a+pkg/proto/configuration/global/global.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\"\xfe\x03\n" +
+	"Ygithub.com/buildbarn/bb-storage/pkg/proto/configuration/bb_replicator/bb_replicator.proto\x12%buildbarn.configuration.bb_replicator\x1aQgithub.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto\x1aKgithub.com/buildbarn/bb-storage/pkg/proto/configuration/global/global.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\"\xfe\x03\n" +
 	"\x18ApplicationConfiguration\x12T\n" +
 	"\fgrpc_servers\x18\x02 \x03(\v21.buildbarn.configuration.grpc.ServerConfigurationR\vgrpcServers\x12R\n" +
 	"\x06source\x18\x03 \x01(\v2:.buildbarn.configuration.blobstore.BlobAccessConfigurationR\x06source\x12N\n" +
@@ -124,26 +124,26 @@ const file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc = "
 	"\x06global\x18\a \x01(\v2-.buildbarn.configuration.global.ConfigurationR\x06globalJ\x04\b\x01\x10\x02BGZEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/bb_replicatorb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc), len(file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_goTypes = []any{
 	(*ApplicationConfiguration)(nil),              // 0: buildbarn.configuration.bb_replicator.ApplicationConfiguration
 	(*grpc.ServerConfiguration)(nil),              // 1: buildbarn.configuration.grpc.ServerConfiguration
 	(*blobstore.BlobAccessConfiguration)(nil),     // 2: buildbarn.configuration.blobstore.BlobAccessConfiguration
 	(*blobstore.BlobReplicatorConfiguration)(nil), // 3: buildbarn.configuration.blobstore.BlobReplicatorConfiguration
 	(*global.Configuration)(nil),                  // 4: buildbarn.configuration.global.Configuration
 }
-var file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.bb_replicator.ApplicationConfiguration.grpc_servers:type_name -> buildbarn.configuration.grpc.ServerConfiguration
 	2, // 1: buildbarn.configuration.bb_replicator.ApplicationConfiguration.source:type_name -> buildbarn.configuration.blobstore.BlobAccessConfiguration
 	2, // 2: buildbarn.configuration.bb_replicator.ApplicationConfiguration.sink:type_name -> buildbarn.configuration.blobstore.BlobAccessConfiguration
@@ -156,26 +156,28 @@ var file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_depIdxs = []i
 	0, // [0:5] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_init() }
-func file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_init() {
-	if File_pkg_proto_configuration_bb_replicator_bb_replicator_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc), len(file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_bb_replicator_bb_replicator_proto = out.File
-	file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_goTypes = nil
-	file_pkg_proto_configuration_bb_replicator_bb_replicator_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_replicator_bb_replicator_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/bb_replicator/bb_replicator.proto
+++ b/pkg/proto/configuration/bb_replicator/bb_replicator.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package buildbarn.configuration.bb_replicator;
 
-import "pkg/proto/configuration/blobstore/blobstore.proto";
-import "pkg/proto/configuration/global/global.proto";
-import "pkg/proto/configuration/grpc/grpc.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/global/global.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/bb_replicator";
 

--- a/pkg/proto/configuration/bb_storage/BUILD.bazel
+++ b/pkg/proto/configuration/bb_storage/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "bb_storage_proto",
     srcs = ["bb_storage.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/auth:auth_proto",

--- a/pkg/proto/configuration/bb_storage/bb_storage.pb.go
+++ b/pkg/proto/configuration/bb_storage/bb_storage.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/bb_storage/bb_storage.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/bb_storage/bb_storage.proto
 
 package bb_storage
 
@@ -46,7 +46,7 @@ type ApplicationConfiguration struct {
 
 func (x *ApplicationConfiguration) Reset() {
 	*x = ApplicationConfiguration{}
-	mi := &file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -58,7 +58,7 @@ func (x *ApplicationConfiguration) String() string {
 func (*ApplicationConfiguration) ProtoMessage() {}
 
 func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -71,7 +71,7 @@ func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplicationConfiguration.ProtoReflect.Descriptor instead.
 func (*ApplicationConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ApplicationConfiguration) GetGrpcServers() []*grpc.ServerConfiguration {
@@ -162,7 +162,7 @@ type NonScannableBlobAccessConfiguration struct {
 
 func (x *NonScannableBlobAccessConfiguration) Reset() {
 	*x = NonScannableBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -174,7 +174,7 @@ func (x *NonScannableBlobAccessConfiguration) String() string {
 func (*NonScannableBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *NonScannableBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -187,7 +187,7 @@ func (x *NonScannableBlobAccessConfiguration) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use NonScannableBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*NonScannableBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *NonScannableBlobAccessConfiguration) GetBackend() *blobstore.BlobAccessConfiguration {
@@ -223,7 +223,7 @@ type ScannableBlobAccessConfiguration struct {
 
 func (x *ScannableBlobAccessConfiguration) Reset() {
 	*x = ScannableBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -235,7 +235,7 @@ func (x *ScannableBlobAccessConfiguration) String() string {
 func (*ScannableBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ScannableBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -248,7 +248,7 @@ func (x *ScannableBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ScannableBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ScannableBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ScannableBlobAccessConfiguration) GetBackend() *blobstore.BlobAccessConfiguration {
@@ -279,11 +279,11 @@ func (x *ScannableBlobAccessConfiguration) GetFindMissingAuthorizer() *auth.Auth
 	return nil
 }
 
-var File_pkg_proto_configuration_bb_storage_bb_storage_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc = "" +
 	"\n" +
-	"3pkg/proto/configuration/bb_storage/bb_storage.proto\x12\"buildbarn.configuration.bb_storage\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a'pkg/proto/configuration/auth/auth.proto\x1a1pkg/proto/configuration/blobstore/blobstore.proto\x1a-pkg/proto/configuration/builder/builder.proto\x1a+pkg/proto/configuration/global/global.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\"\xef\n" +
+	"Sgithub.com/buildbarn/bb-storage/pkg/proto/configuration/bb_storage/bb_storage.proto\x12\"buildbarn.configuration.bb_storage\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/auth/auth.proto\x1aQgithub.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto\x1aMgithub.com/buildbarn/bb-storage/pkg/proto/configuration/builder/builder.proto\x1aKgithub.com/buildbarn/bb-storage/pkg/proto/configuration/global/global.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\"\xef\n" +
 	"\n" +
 	"\x18ApplicationConfiguration\x12T\n" +
 	"\fgrpc_servers\x18\x04 \x03(\v21.buildbarn.configuration.grpc.ServerConfigurationR\vgrpcServers\x12l\n" +
@@ -314,19 +314,19 @@ const file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc = "" +
 	"\x17find_missing_authorizer\x18\x04 \x01(\v25.buildbarn.configuration.auth.AuthorizerConfigurationR\x15findMissingAuthorizerBDZBgithub.com/buildbarn/bb-storage/pkg/proto/configuration/bb_storageb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc), len(file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_pkg_proto_configuration_bb_storage_bb_storage_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_goTypes = []any{
 	(*ApplicationConfiguration)(nil),            // 0: buildbarn.configuration.bb_storage.ApplicationConfiguration
 	(*NonScannableBlobAccessConfiguration)(nil), // 1: buildbarn.configuration.bb_storage.NonScannableBlobAccessConfiguration
 	(*ScannableBlobAccessConfiguration)(nil),    // 2: buildbarn.configuration.bb_storage.ScannableBlobAccessConfiguration
@@ -338,7 +338,7 @@ var file_pkg_proto_configuration_bb_storage_bb_storage_proto_goTypes = []any{
 	(*blobstore.BlobAccessConfiguration)(nil),   // 8: buildbarn.configuration.blobstore.BlobAccessConfiguration
 	(*builder.SchedulerConfiguration)(nil),      // 9: buildbarn.configuration.builder.SchedulerConfiguration
 }
-var file_pkg_proto_configuration_bb_storage_bb_storage_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_depIdxs = []int32{
 	4,  // 0: buildbarn.configuration.bb_storage.ApplicationConfiguration.grpc_servers:type_name -> buildbarn.configuration.grpc.ServerConfiguration
 	3,  // 1: buildbarn.configuration.bb_storage.ApplicationConfiguration.schedulers:type_name -> buildbarn.configuration.bb_storage.ApplicationConfiguration.SchedulersEntry
 	5,  // 2: buildbarn.configuration.bb_storage.ApplicationConfiguration.global:type_name -> buildbarn.configuration.global.Configuration
@@ -364,26 +364,28 @@ var file_pkg_proto_configuration_bb_storage_bb_storage_proto_depIdxs = []int32{
 	0,  // [0:18] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_bb_storage_bb_storage_proto_init() }
-func file_pkg_proto_configuration_bb_storage_bb_storage_proto_init() {
-	if File_pkg_proto_configuration_bb_storage_bb_storage_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc), len(file_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_bb_storage_bb_storage_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_bb_storage_bb_storage_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_bb_storage_bb_storage_proto = out.File
-	file_pkg_proto_configuration_bb_storage_bb_storage_proto_goTypes = nil
-	file_pkg_proto_configuration_bb_storage_bb_storage_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_bb_storage_bb_storage_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/bb_storage/bb_storage.proto
+++ b/pkg/proto/configuration/bb_storage/bb_storage.proto
@@ -3,11 +3,11 @@ syntax = "proto3";
 package buildbarn.configuration.bb_storage;
 
 import "build/bazel/remote/execution/v2/remote_execution.proto";
-import "pkg/proto/configuration/auth/auth.proto";
-import "pkg/proto/configuration/blobstore/blobstore.proto";
-import "pkg/proto/configuration/builder/builder.proto";
-import "pkg/proto/configuration/global/global.proto";
-import "pkg/proto/configuration/grpc/grpc.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/auth/auth.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/builder/builder.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/global/global.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/bb_storage";
 

--- a/pkg/proto/configuration/blobstore/BUILD.bazel
+++ b/pkg/proto/configuration/blobstore/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "blobstore_proto",
     srcs = ["blobstore.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/blockdevice:blockdevice_proto",

--- a/pkg/proto/configuration/blobstore/blobstore.pb.go
+++ b/pkg/proto/configuration/blobstore/blobstore.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/blobstore/blobstore.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto
 
 package blobstore
 
@@ -41,7 +41,7 @@ type BlobstoreConfiguration struct {
 
 func (x *BlobstoreConfiguration) Reset() {
 	*x = BlobstoreConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53,7 +53,7 @@ func (x *BlobstoreConfiguration) String() string {
 func (*BlobstoreConfiguration) ProtoMessage() {}
 
 func (x *BlobstoreConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66,7 +66,7 @@ func (x *BlobstoreConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlobstoreConfiguration.ProtoReflect.Descriptor instead.
 func (*BlobstoreConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *BlobstoreConfiguration) GetContentAddressableStorage() *BlobAccessConfiguration {
@@ -113,7 +113,7 @@ type BlobAccessConfiguration struct {
 
 func (x *BlobAccessConfiguration) Reset() {
 	*x = BlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -125,7 +125,7 @@ func (x *BlobAccessConfiguration) String() string {
 func (*BlobAccessConfiguration) ProtoMessage() {}
 
 func (x *BlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -138,7 +138,7 @@ func (x *BlobAccessConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*BlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *BlobAccessConfiguration) GetBackend() isBlobAccessConfiguration_Backend {
@@ -448,7 +448,7 @@ type ReadCachingBlobAccessConfiguration struct {
 
 func (x *ReadCachingBlobAccessConfiguration) Reset() {
 	*x = ReadCachingBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -460,7 +460,7 @@ func (x *ReadCachingBlobAccessConfiguration) String() string {
 func (*ReadCachingBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ReadCachingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -473,7 +473,7 @@ func (x *ReadCachingBlobAccessConfiguration) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use ReadCachingBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ReadCachingBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ReadCachingBlobAccessConfiguration) GetSlow() *BlobAccessConfiguration {
@@ -507,7 +507,7 @@ type ShardingBlobAccessConfiguration struct {
 
 func (x *ShardingBlobAccessConfiguration) Reset() {
 	*x = ShardingBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -519,7 +519,7 @@ func (x *ShardingBlobAccessConfiguration) String() string {
 func (*ShardingBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ShardingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -532,7 +532,7 @@ func (x *ShardingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ShardingBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ShardingBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{3}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ShardingBlobAccessConfiguration) GetShards() map[string]*ShardingBlobAccessConfiguration_Shard {
@@ -561,7 +561,7 @@ type MirroredBlobAccessConfiguration struct {
 
 func (x *MirroredBlobAccessConfiguration) Reset() {
 	*x = MirroredBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -573,7 +573,7 @@ func (x *MirroredBlobAccessConfiguration) String() string {
 func (*MirroredBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *MirroredBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -586,7 +586,7 @@ func (x *MirroredBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use MirroredBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*MirroredBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{4}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *MirroredBlobAccessConfiguration) GetBackendA() *BlobAccessConfiguration {
@@ -642,7 +642,7 @@ type LocalBlobAccessConfiguration struct {
 
 func (x *LocalBlobAccessConfiguration) Reset() {
 	*x = LocalBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -654,7 +654,7 @@ func (x *LocalBlobAccessConfiguration) String() string {
 func (*LocalBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *LocalBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -667,7 +667,7 @@ func (x *LocalBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use LocalBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*LocalBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *LocalBlobAccessConfiguration) GetKeyLocationMapBackend() isLocalBlobAccessConfiguration_KeyLocationMapBackend {
@@ -814,7 +814,7 @@ type ExistenceCachingBlobAccessConfiguration struct {
 
 func (x *ExistenceCachingBlobAccessConfiguration) Reset() {
 	*x = ExistenceCachingBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -826,7 +826,7 @@ func (x *ExistenceCachingBlobAccessConfiguration) String() string {
 func (*ExistenceCachingBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ExistenceCachingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -839,7 +839,7 @@ func (x *ExistenceCachingBlobAccessConfiguration) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use ExistenceCachingBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ExistenceCachingBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{6}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *ExistenceCachingBlobAccessConfiguration) GetBackend() *BlobAccessConfiguration {
@@ -866,7 +866,7 @@ type CompletenessCheckingBlobAccessConfiguration struct {
 
 func (x *CompletenessCheckingBlobAccessConfiguration) Reset() {
 	*x = CompletenessCheckingBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[7]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -878,7 +878,7 @@ func (x *CompletenessCheckingBlobAccessConfiguration) String() string {
 func (*CompletenessCheckingBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *CompletenessCheckingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[7]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -891,7 +891,7 @@ func (x *CompletenessCheckingBlobAccessConfiguration) ProtoReflect() protoreflec
 
 // Deprecated: Use CompletenessCheckingBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*CompletenessCheckingBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{7}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *CompletenessCheckingBlobAccessConfiguration) GetBackend() *BlobAccessConfiguration {
@@ -919,7 +919,7 @@ type ReadFallbackBlobAccessConfiguration struct {
 
 func (x *ReadFallbackBlobAccessConfiguration) Reset() {
 	*x = ReadFallbackBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[8]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -931,7 +931,7 @@ func (x *ReadFallbackBlobAccessConfiguration) String() string {
 func (*ReadFallbackBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ReadFallbackBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[8]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -944,7 +944,7 @@ func (x *ReadFallbackBlobAccessConfiguration) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use ReadFallbackBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ReadFallbackBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{8}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *ReadFallbackBlobAccessConfiguration) GetPrimary() *BlobAccessConfiguration {
@@ -981,7 +981,7 @@ type ReferenceExpandingBlobAccessConfiguration struct {
 
 func (x *ReferenceExpandingBlobAccessConfiguration) Reset() {
 	*x = ReferenceExpandingBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[9]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -993,7 +993,7 @@ func (x *ReferenceExpandingBlobAccessConfiguration) String() string {
 func (*ReferenceExpandingBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ReferenceExpandingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[9]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1006,7 +1006,7 @@ func (x *ReferenceExpandingBlobAccessConfiguration) ProtoReflect() protoreflect.
 
 // Deprecated: Use ReferenceExpandingBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ReferenceExpandingBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{9}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *ReferenceExpandingBlobAccessConfiguration) GetIndirectContentAddressableStorage() *BlobAccessConfiguration {
@@ -1061,7 +1061,7 @@ type BlobReplicatorConfiguration struct {
 
 func (x *BlobReplicatorConfiguration) Reset() {
 	*x = BlobReplicatorConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[10]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1073,7 +1073,7 @@ func (x *BlobReplicatorConfiguration) String() string {
 func (*BlobReplicatorConfiguration) ProtoMessage() {}
 
 func (x *BlobReplicatorConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[10]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1086,7 +1086,7 @@ func (x *BlobReplicatorConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BlobReplicatorConfiguration.ProtoReflect.Descriptor instead.
 func (*BlobReplicatorConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{10}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *BlobReplicatorConfiguration) GetMode() isBlobReplicatorConfiguration_Mode {
@@ -1200,7 +1200,7 @@ type QueuedBlobReplicatorConfiguration struct {
 
 func (x *QueuedBlobReplicatorConfiguration) Reset() {
 	*x = QueuedBlobReplicatorConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[11]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1212,7 +1212,7 @@ func (x *QueuedBlobReplicatorConfiguration) String() string {
 func (*QueuedBlobReplicatorConfiguration) ProtoMessage() {}
 
 func (x *QueuedBlobReplicatorConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[11]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1225,7 +1225,7 @@ func (x *QueuedBlobReplicatorConfiguration) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use QueuedBlobReplicatorConfiguration.ProtoReflect.Descriptor instead.
 func (*QueuedBlobReplicatorConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{11}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{11}
 }
 
 func (x *QueuedBlobReplicatorConfiguration) GetBase() *BlobReplicatorConfiguration {
@@ -1252,7 +1252,7 @@ type ConcurrencyLimitingBlobReplicatorConfiguration struct {
 
 func (x *ConcurrencyLimitingBlobReplicatorConfiguration) Reset() {
 	*x = ConcurrencyLimitingBlobReplicatorConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[12]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1264,7 +1264,7 @@ func (x *ConcurrencyLimitingBlobReplicatorConfiguration) String() string {
 func (*ConcurrencyLimitingBlobReplicatorConfiguration) ProtoMessage() {}
 
 func (x *ConcurrencyLimitingBlobReplicatorConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[12]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1277,7 +1277,7 @@ func (x *ConcurrencyLimitingBlobReplicatorConfiguration) ProtoReflect() protoref
 
 // Deprecated: Use ConcurrencyLimitingBlobReplicatorConfiguration.ProtoReflect.Descriptor instead.
 func (*ConcurrencyLimitingBlobReplicatorConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{12}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{12}
 }
 
 func (x *ConcurrencyLimitingBlobReplicatorConfiguration) GetBase() *BlobReplicatorConfiguration {
@@ -1303,7 +1303,7 @@ type DemultiplexingBlobAccessConfiguration struct {
 
 func (x *DemultiplexingBlobAccessConfiguration) Reset() {
 	*x = DemultiplexingBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[13]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1315,7 +1315,7 @@ func (x *DemultiplexingBlobAccessConfiguration) String() string {
 func (*DemultiplexingBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *DemultiplexingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[13]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1328,7 +1328,7 @@ func (x *DemultiplexingBlobAccessConfiguration) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use DemultiplexingBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*DemultiplexingBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{13}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{13}
 }
 
 func (x *DemultiplexingBlobAccessConfiguration) GetInstanceNamePrefixes() map[string]*DemultiplexedBlobAccessConfiguration {
@@ -1348,7 +1348,7 @@ type DemultiplexedBlobAccessConfiguration struct {
 
 func (x *DemultiplexedBlobAccessConfiguration) Reset() {
 	*x = DemultiplexedBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[14]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1360,7 +1360,7 @@ func (x *DemultiplexedBlobAccessConfiguration) String() string {
 func (*DemultiplexedBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *DemultiplexedBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[14]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1373,7 +1373,7 @@ func (x *DemultiplexedBlobAccessConfiguration) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use DemultiplexedBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*DemultiplexedBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{14}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{14}
 }
 
 func (x *DemultiplexedBlobAccessConfiguration) GetBackend() *BlobAccessConfiguration {
@@ -1402,7 +1402,7 @@ type ActionResultExpiringBlobAccessConfiguration struct {
 
 func (x *ActionResultExpiringBlobAccessConfiguration) Reset() {
 	*x = ActionResultExpiringBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[15]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1414,7 +1414,7 @@ func (x *ActionResultExpiringBlobAccessConfiguration) String() string {
 func (*ActionResultExpiringBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ActionResultExpiringBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[15]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1427,7 +1427,7 @@ func (x *ActionResultExpiringBlobAccessConfiguration) ProtoReflect() protoreflec
 
 // Deprecated: Use ActionResultExpiringBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ActionResultExpiringBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{15}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{15}
 }
 
 func (x *ActionResultExpiringBlobAccessConfiguration) GetBackend() *BlobAccessConfiguration {
@@ -1470,7 +1470,7 @@ type ReadCanaryingBlobAccessConfiguration struct {
 
 func (x *ReadCanaryingBlobAccessConfiguration) Reset() {
 	*x = ReadCanaryingBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[16]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[16]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1482,7 +1482,7 @@ func (x *ReadCanaryingBlobAccessConfiguration) String() string {
 func (*ReadCanaryingBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ReadCanaryingBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[16]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[16]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1495,7 +1495,7 @@ func (x *ReadCanaryingBlobAccessConfiguration) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use ReadCanaryingBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ReadCanaryingBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{16}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{16}
 }
 
 func (x *ReadCanaryingBlobAccessConfiguration) GetSource() *BlobAccessConfiguration {
@@ -1536,7 +1536,7 @@ type ZIPBlobAccessConfiguration struct {
 
 func (x *ZIPBlobAccessConfiguration) Reset() {
 	*x = ZIPBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[17]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1548,7 +1548,7 @@ func (x *ZIPBlobAccessConfiguration) String() string {
 func (*ZIPBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *ZIPBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[17]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1561,7 +1561,7 @@ func (x *ZIPBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ZIPBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*ZIPBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{17}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{17}
 }
 
 func (x *ZIPBlobAccessConfiguration) GetPath() string {
@@ -1588,7 +1588,7 @@ type WithLabelsBlobAccessConfiguration struct {
 
 func (x *WithLabelsBlobAccessConfiguration) Reset() {
 	*x = WithLabelsBlobAccessConfiguration{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[18]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1600,7 +1600,7 @@ func (x *WithLabelsBlobAccessConfiguration) String() string {
 func (*WithLabelsBlobAccessConfiguration) ProtoMessage() {}
 
 func (x *WithLabelsBlobAccessConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[18]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1613,7 +1613,7 @@ func (x *WithLabelsBlobAccessConfiguration) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use WithLabelsBlobAccessConfiguration.ProtoReflect.Descriptor instead.
 func (*WithLabelsBlobAccessConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{18}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{18}
 }
 
 func (x *WithLabelsBlobAccessConfiguration) GetBackend() *BlobAccessConfiguration {
@@ -1640,7 +1640,7 @@ type DeadlineEnforcingBlobAccess struct {
 
 func (x *DeadlineEnforcingBlobAccess) Reset() {
 	*x = DeadlineEnforcingBlobAccess{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[19]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[19]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1652,7 +1652,7 @@ func (x *DeadlineEnforcingBlobAccess) String() string {
 func (*DeadlineEnforcingBlobAccess) ProtoMessage() {}
 
 func (x *DeadlineEnforcingBlobAccess) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[19]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[19]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1665,7 +1665,7 @@ func (x *DeadlineEnforcingBlobAccess) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use DeadlineEnforcingBlobAccess.ProtoReflect.Descriptor instead.
 func (*DeadlineEnforcingBlobAccess) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{19}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{19}
 }
 
 func (x *DeadlineEnforcingBlobAccess) GetTimeout() *durationpb.Duration {
@@ -1692,7 +1692,7 @@ type ShardingBlobAccessConfiguration_Shard struct {
 
 func (x *ShardingBlobAccessConfiguration_Shard) Reset() {
 	*x = ShardingBlobAccessConfiguration_Shard{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[20]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[20]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1704,7 +1704,7 @@ func (x *ShardingBlobAccessConfiguration_Shard) String() string {
 func (*ShardingBlobAccessConfiguration_Shard) ProtoMessage() {}
 
 func (x *ShardingBlobAccessConfiguration_Shard) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[20]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[20]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1717,7 +1717,7 @@ func (x *ShardingBlobAccessConfiguration_Shard) ProtoReflect() protoreflect.Mess
 
 // Deprecated: Use ShardingBlobAccessConfiguration_Shard.ProtoReflect.Descriptor instead.
 func (*ShardingBlobAccessConfiguration_Shard) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{3, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{3, 0}
 }
 
 func (x *ShardingBlobAccessConfiguration_Shard) GetBackend() *BlobAccessConfiguration {
@@ -1744,7 +1744,7 @@ type ShardingBlobAccessConfiguration_Legacy struct {
 
 func (x *ShardingBlobAccessConfiguration_Legacy) Reset() {
 	*x = ShardingBlobAccessConfiguration_Legacy{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[21]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[21]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1756,7 +1756,7 @@ func (x *ShardingBlobAccessConfiguration_Legacy) String() string {
 func (*ShardingBlobAccessConfiguration_Legacy) ProtoMessage() {}
 
 func (x *ShardingBlobAccessConfiguration_Legacy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[21]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[21]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1769,7 +1769,7 @@ func (x *ShardingBlobAccessConfiguration_Legacy) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use ShardingBlobAccessConfiguration_Legacy.ProtoReflect.Descriptor instead.
 func (*ShardingBlobAccessConfiguration_Legacy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{3, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{3, 1}
 }
 
 func (x *ShardingBlobAccessConfiguration_Legacy) GetShardOrder() []string {
@@ -1795,7 +1795,7 @@ type LocalBlobAccessConfiguration_KeyLocationMapInMemory struct {
 
 func (x *LocalBlobAccessConfiguration_KeyLocationMapInMemory) Reset() {
 	*x = LocalBlobAccessConfiguration_KeyLocationMapInMemory{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[23]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[23]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1807,7 +1807,7 @@ func (x *LocalBlobAccessConfiguration_KeyLocationMapInMemory) String() string {
 func (*LocalBlobAccessConfiguration_KeyLocationMapInMemory) ProtoMessage() {}
 
 func (x *LocalBlobAccessConfiguration_KeyLocationMapInMemory) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[23]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[23]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1820,7 +1820,7 @@ func (x *LocalBlobAccessConfiguration_KeyLocationMapInMemory) ProtoReflect() pro
 
 // Deprecated: Use LocalBlobAccessConfiguration_KeyLocationMapInMemory.ProtoReflect.Descriptor instead.
 func (*LocalBlobAccessConfiguration_KeyLocationMapInMemory) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 0}
 }
 
 func (x *LocalBlobAccessConfiguration_KeyLocationMapInMemory) GetEntries() int64 {
@@ -1839,7 +1839,7 @@ type LocalBlobAccessConfiguration_BlocksInMemory struct {
 
 func (x *LocalBlobAccessConfiguration_BlocksInMemory) Reset() {
 	*x = LocalBlobAccessConfiguration_BlocksInMemory{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[24]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[24]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1851,7 +1851,7 @@ func (x *LocalBlobAccessConfiguration_BlocksInMemory) String() string {
 func (*LocalBlobAccessConfiguration_BlocksInMemory) ProtoMessage() {}
 
 func (x *LocalBlobAccessConfiguration_BlocksInMemory) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[24]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[24]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1864,7 +1864,7 @@ func (x *LocalBlobAccessConfiguration_BlocksInMemory) ProtoReflect() protoreflec
 
 // Deprecated: Use LocalBlobAccessConfiguration_BlocksInMemory.ProtoReflect.Descriptor instead.
 func (*LocalBlobAccessConfiguration_BlocksInMemory) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 1}
 }
 
 func (x *LocalBlobAccessConfiguration_BlocksInMemory) GetBlockSizeBytes() int64 {
@@ -1885,7 +1885,7 @@ type LocalBlobAccessConfiguration_BlocksOnBlockDevice struct {
 
 func (x *LocalBlobAccessConfiguration_BlocksOnBlockDevice) Reset() {
 	*x = LocalBlobAccessConfiguration_BlocksOnBlockDevice{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[25]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[25]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1897,7 +1897,7 @@ func (x *LocalBlobAccessConfiguration_BlocksOnBlockDevice) String() string {
 func (*LocalBlobAccessConfiguration_BlocksOnBlockDevice) ProtoMessage() {}
 
 func (x *LocalBlobAccessConfiguration_BlocksOnBlockDevice) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[25]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[25]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1910,7 +1910,7 @@ func (x *LocalBlobAccessConfiguration_BlocksOnBlockDevice) ProtoReflect() protor
 
 // Deprecated: Use LocalBlobAccessConfiguration_BlocksOnBlockDevice.ProtoReflect.Descriptor instead.
 func (*LocalBlobAccessConfiguration_BlocksOnBlockDevice) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 2}
 }
 
 func (x *LocalBlobAccessConfiguration_BlocksOnBlockDevice) GetSource() *blockdevice.Configuration {
@@ -1944,7 +1944,7 @@ type LocalBlobAccessConfiguration_Persistent struct {
 
 func (x *LocalBlobAccessConfiguration_Persistent) Reset() {
 	*x = LocalBlobAccessConfiguration_Persistent{}
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[26]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[26]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1956,7 +1956,7 @@ func (x *LocalBlobAccessConfiguration_Persistent) String() string {
 func (*LocalBlobAccessConfiguration_Persistent) ProtoMessage() {}
 
 func (x *LocalBlobAccessConfiguration_Persistent) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[26]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[26]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1969,7 +1969,7 @@ func (x *LocalBlobAccessConfiguration_Persistent) ProtoReflect() protoreflect.Me
 
 // Deprecated: Use LocalBlobAccessConfiguration_Persistent.ProtoReflect.Descriptor instead.
 func (*LocalBlobAccessConfiguration_Persistent) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 3}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP(), []int{5, 3}
 }
 
 func (x *LocalBlobAccessConfiguration_Persistent) GetStateDirectoryPath() string {
@@ -1986,11 +1986,11 @@ func (x *LocalBlobAccessConfiguration_Persistent) GetMinimumEpochInterval() *dur
 	return nil
 }
 
-var File_pkg_proto_configuration_blobstore_blobstore_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc = "" +
 	"\n" +
-	"1pkg/proto/configuration/blobstore/blobstore.proto\x12!buildbarn.configuration.blobstore\x1a\x17google/rpc/status.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a5pkg/proto/configuration/blockdevice/blockdevice.proto\x1a+pkg/proto/configuration/cloud/aws/aws.proto\x1a+pkg/proto/configuration/cloud/gcp/gcp.proto\x1a+pkg/proto/configuration/digest/digest.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\x1a0pkg/proto/configuration/http/client/client.proto\"\xf3\x01\n" +
+	"Qgithub.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore/blobstore.proto\x12!buildbarn.configuration.blobstore\x1aUgithub.com/buildbarn/bb-storage/pkg/proto/configuration/blockdevice/blockdevice.proto\x1aKgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/aws/aws.proto\x1aKgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/gcp/gcp.proto\x1aKgithub.com/buildbarn/bb-storage/pkg/proto/configuration/digest/digest.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x17google/rpc/status.proto\"\xf3\x01\n" +
 	"\x16BlobstoreConfiguration\x12z\n" +
 	"\x1bcontent_addressable_storage\x18\x01 \x01(\v2:.buildbarn.configuration.blobstore.BlobAccessConfigurationR\x19contentAddressableStorage\x12]\n" +
 	"\faction_cache\x18\x02 \x01(\v2:.buildbarn.configuration.blobstore.BlobAccessConfigurationR\vactionCache\"\xd6\x0f\n" +
@@ -2140,19 +2140,19 @@ const file_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc = "" +
 	"\abackend\x18\x02 \x01(\v2:.buildbarn.configuration.blobstore.BlobAccessConfigurationR\abackendBCZAgithub.com/buildbarn/bb-storage/pkg/proto/configuration/blobstoreb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc), len(file_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_blobstore_blobstore_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
-var file_pkg_proto_configuration_blobstore_blobstore_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes = make([]protoimpl.MessageInfo, 29)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_goTypes = []any{
 	(*BlobstoreConfiguration)(nil),                         // 0: buildbarn.configuration.blobstore.BlobstoreConfiguration
 	(*BlobAccessConfiguration)(nil),                        // 1: buildbarn.configuration.blobstore.BlobAccessConfiguration
 	(*ReadCachingBlobAccessConfiguration)(nil),             // 2: buildbarn.configuration.blobstore.ReadCachingBlobAccessConfiguration
@@ -2193,7 +2193,7 @@ var file_pkg_proto_configuration_blobstore_blobstore_proto_goTypes = []any{
 	(*durationpb.Duration)(nil),                // 37: google.protobuf.Duration
 	(*timestamppb.Timestamp)(nil),              // 38: google.protobuf.Timestamp
 }
-var file_pkg_proto_configuration_blobstore_blobstore_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_depIdxs = []int32{
 	1,  // 0: buildbarn.configuration.blobstore.BlobstoreConfiguration.content_addressable_storage:type_name -> buildbarn.configuration.blobstore.BlobAccessConfiguration
 	1,  // 1: buildbarn.configuration.blobstore.BlobstoreConfiguration.action_cache:type_name -> buildbarn.configuration.blobstore.BlobAccessConfiguration
 	2,  // 2: buildbarn.configuration.blobstore.BlobAccessConfiguration.read_caching:type_name -> buildbarn.configuration.blobstore.ReadCachingBlobAccessConfiguration
@@ -2276,12 +2276,14 @@ var file_pkg_proto_configuration_blobstore_blobstore_proto_depIdxs = []int32{
 	0,  // [0:75] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_blobstore_blobstore_proto_init() }
-func file_pkg_proto_configuration_blobstore_blobstore_proto_init() {
-	if File_pkg_proto_configuration_blobstore_blobstore_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[1].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[1].OneofWrappers = []any{
 		(*BlobAccessConfiguration_ReadCaching)(nil),
 		(*BlobAccessConfiguration_Grpc)(nil),
 		(*BlobAccessConfiguration_Error)(nil),
@@ -2302,13 +2304,13 @@ func file_pkg_proto_configuration_blobstore_blobstore_proto_init() {
 		(*BlobAccessConfiguration_Label)(nil),
 		(*BlobAccessConfiguration_DeadlineEnforcing)(nil),
 	}
-	file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[5].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[5].OneofWrappers = []any{
 		(*LocalBlobAccessConfiguration_KeyLocationMapInMemory_)(nil),
 		(*LocalBlobAccessConfiguration_KeyLocationMapOnBlockDevice)(nil),
 		(*LocalBlobAccessConfiguration_BlocksInMemory_)(nil),
 		(*LocalBlobAccessConfiguration_BlocksOnBlockDevice_)(nil),
 	}
-	file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[10].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes[10].OneofWrappers = []any{
 		(*BlobReplicatorConfiguration_Local)(nil),
 		(*BlobReplicatorConfiguration_Remote)(nil),
 		(*BlobReplicatorConfiguration_Queued)(nil),
@@ -2320,17 +2322,17 @@ func file_pkg_proto_configuration_blobstore_blobstore_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc), len(file_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   29,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_blobstore_blobstore_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_blobstore_blobstore_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_blobstore_blobstore_proto = out.File
-	file_pkg_proto_configuration_blobstore_blobstore_proto_goTypes = nil
-	file_pkg_proto_configuration_blobstore_blobstore_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blobstore_blobstore_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/blobstore/blobstore.proto
+++ b/pkg/proto/configuration/blobstore/blobstore.proto
@@ -2,16 +2,16 @@ syntax = "proto3";
 
 package buildbarn.configuration.blobstore;
 
-import "google/rpc/status.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/blockdevice/blockdevice.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/aws/aws.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/gcp/gcp.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/digest/digest.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/timestamp.proto";
-import "pkg/proto/configuration/blockdevice/blockdevice.proto";
-import "pkg/proto/configuration/cloud/aws/aws.proto";
-import "pkg/proto/configuration/cloud/gcp/gcp.proto";
-import "pkg/proto/configuration/digest/digest.proto";
-import "pkg/proto/configuration/grpc/grpc.proto";
-import "pkg/proto/configuration/http/client/client.proto";
+import "google/rpc/status.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/blobstore";
 

--- a/pkg/proto/configuration/blockdevice/BUILD.bazel
+++ b/pkg/proto/configuration/blockdevice/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "blockdevice_proto",
     srcs = ["blockdevice.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/proto/configuration/blockdevice/blockdevice.pb.go
+++ b/pkg/proto/configuration/blockdevice/blockdevice.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/blockdevice/blockdevice.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/blockdevice/blockdevice.proto
 
 package blockdevice
 
@@ -31,7 +31,7 @@ type FileConfiguration struct {
 
 func (x *FileConfiguration) Reset() {
 	*x = FileConfiguration{}
-	mi := &file_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -43,7 +43,7 @@ func (x *FileConfiguration) String() string {
 func (*FileConfiguration) ProtoMessage() {}
 
 func (x *FileConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -56,7 +56,7 @@ func (x *FileConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileConfiguration.ProtoReflect.Descriptor instead.
 func (*FileConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *FileConfiguration) GetPath() string {
@@ -87,7 +87,7 @@ type Configuration struct {
 
 func (x *Configuration) Reset() {
 	*x = Configuration{}
-	mi := &file_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -99,7 +99,7 @@ func (x *Configuration) String() string {
 func (*Configuration) ProtoMessage() {}
 
 func (x *Configuration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -112,7 +112,7 @@ func (x *Configuration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Configuration.ProtoReflect.Descriptor instead.
 func (*Configuration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *Configuration) GetSource() isConfiguration_Source {
@@ -163,11 +163,11 @@ func (*Configuration_DevicePath) isConfiguration_Source() {}
 
 func (*Configuration_File) isConfiguration_Source() {}
 
-var File_pkg_proto_configuration_blockdevice_blockdevice_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc = "" +
 	"\n" +
-	"5pkg/proto/configuration/blockdevice/blockdevice.proto\x12#buildbarn.configuration.blockdevice\"F\n" +
+	"Ugithub.com/buildbarn/bb-storage/pkg/proto/configuration/blockdevice/blockdevice.proto\x12#buildbarn.configuration.blockdevice\"F\n" +
 	"\x11FileConfiguration\x12\x12\n" +
 	"\x04path\x18\x01 \x01(\tR\x04path\x12\x1d\n" +
 	"\n" +
@@ -180,23 +180,23 @@ const file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc = "" +
 	"\x06sourceBEZCgithub.com/buildbarn/bb-storage/pkg/proto/configuration/blockdeviceb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc), len(file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
-var file_pkg_proto_configuration_blockdevice_blockdevice_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_goTypes = []any{
 	(*FileConfiguration)(nil), // 0: buildbarn.configuration.blockdevice.FileConfiguration
 	(*Configuration)(nil),     // 1: buildbarn.configuration.blockdevice.Configuration
 }
-var file_pkg_proto_configuration_blockdevice_blockdevice_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_depIdxs = []int32{
 	0, // 0: buildbarn.configuration.blockdevice.Configuration.file:type_name -> buildbarn.configuration.blockdevice.FileConfiguration
 	1, // [1:1] is the sub-list for method output_type
 	1, // [1:1] is the sub-list for method input_type
@@ -205,12 +205,14 @@ var file_pkg_proto_configuration_blockdevice_blockdevice_proto_depIdxs = []int32
 	0, // [0:1] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_blockdevice_blockdevice_proto_init() }
-func file_pkg_proto_configuration_blockdevice_blockdevice_proto_init() {
-	if File_pkg_proto_configuration_blockdevice_blockdevice_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[1].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes[1].OneofWrappers = []any{
 		(*Configuration_DevicePath)(nil),
 		(*Configuration_File)(nil),
 	}
@@ -218,17 +220,17 @@ func file_pkg_proto_configuration_blockdevice_blockdevice_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc), len(file_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   2,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_blockdevice_blockdevice_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_blockdevice_blockdevice_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_blockdevice_blockdevice_proto = out.File
-	file_pkg_proto_configuration_blockdevice_blockdevice_proto_goTypes = nil
-	file_pkg_proto_configuration_blockdevice_blockdevice_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_blockdevice_blockdevice_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/builder/BUILD.bazel
+++ b/pkg/proto/configuration/builder/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "builder_proto",
     srcs = ["builder.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = ["//pkg/proto/configuration/grpc:grpc_proto"],
 )

--- a/pkg/proto/configuration/builder/builder.pb.go
+++ b/pkg/proto/configuration/builder/builder.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/builder/builder.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/builder/builder.proto
 
 package builder
 
@@ -32,7 +32,7 @@ type SchedulerConfiguration struct {
 
 func (x *SchedulerConfiguration) Reset() {
 	*x = SchedulerConfiguration{}
-	mi := &file_pkg_proto_configuration_builder_builder_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -44,7 +44,7 @@ func (x *SchedulerConfiguration) String() string {
 func (*SchedulerConfiguration) ProtoMessage() {}
 
 func (x *SchedulerConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_builder_builder_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57,7 +57,7 @@ func (x *SchedulerConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SchedulerConfiguration.ProtoReflect.Descriptor instead.
 func (*SchedulerConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_builder_builder_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *SchedulerConfiguration) GetEndpoint() *grpc.ClientConfiguration {
@@ -74,33 +74,33 @@ func (x *SchedulerConfiguration) GetAddInstanceNamePrefix() string {
 	return ""
 }
 
-var File_pkg_proto_configuration_builder_builder_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_builder_builder_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDesc = "" +
 	"\n" +
-	"-pkg/proto/configuration/builder/builder.proto\x12\x1fbuildbarn.configuration.builder\x1a'pkg/proto/configuration/grpc/grpc.proto\"\xa0\x01\n" +
+	"Mgithub.com/buildbarn/bb-storage/pkg/proto/configuration/builder/builder.proto\x12\x1fbuildbarn.configuration.builder\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\"\xa0\x01\n" +
 	"\x16SchedulerConfiguration\x12M\n" +
 	"\bendpoint\x18\x01 \x01(\v21.buildbarn.configuration.grpc.ClientConfigurationR\bendpoint\x127\n" +
 	"\x18add_instance_name_prefix\x18\x02 \x01(\tR\x15addInstanceNamePrefixBPB\rConfigBuilderZ?github.com/buildbarn/bb-storage/pkg/proto/configuration/builderb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_builder_builder_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_builder_builder_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_builder_builder_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_builder_builder_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_builder_builder_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_builder_builder_proto_rawDesc), len(file_pkg_proto_configuration_builder_builder_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_builder_builder_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_builder_builder_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_builder_builder_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_goTypes = []any{
 	(*SchedulerConfiguration)(nil),   // 0: buildbarn.configuration.builder.SchedulerConfiguration
 	(*grpc.ClientConfiguration)(nil), // 1: buildbarn.configuration.grpc.ClientConfiguration
 }
-var file_pkg_proto_configuration_builder_builder_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.builder.SchedulerConfiguration.endpoint:type_name -> buildbarn.configuration.grpc.ClientConfiguration
 	1, // [1:1] is the sub-list for method output_type
 	1, // [1:1] is the sub-list for method input_type
@@ -109,26 +109,28 @@ var file_pkg_proto_configuration_builder_builder_proto_depIdxs = []int32{
 	0, // [0:1] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_builder_builder_proto_init() }
-func file_pkg_proto_configuration_builder_builder_proto_init() {
-	if File_pkg_proto_configuration_builder_builder_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_builder_builder_proto_rawDesc), len(file_pkg_proto_configuration_builder_builder_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_builder_builder_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_builder_builder_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_builder_builder_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_builder_builder_proto = out.File
-	file_pkg_proto_configuration_builder_builder_proto_goTypes = nil
-	file_pkg_proto_configuration_builder_builder_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_builder_builder_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/builder/builder.proto
+++ b/pkg/proto/configuration/builder/builder.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package buildbarn.configuration.builder;
 
-import "pkg/proto/configuration/grpc/grpc.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/builder";
 

--- a/pkg/proto/configuration/cloud/aws/BUILD.bazel
+++ b/pkg/proto/configuration/cloud/aws/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "aws_proto",
     srcs = ["aws.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = ["//pkg/proto/configuration/http/client:client_proto"],
 )

--- a/pkg/proto/configuration/cloud/aws/aws.pb.go
+++ b/pkg/proto/configuration/cloud/aws/aws.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/cloud/aws/aws.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/aws/aws.proto
 
 package aws
 
@@ -32,7 +32,7 @@ type StaticCredentials struct {
 
 func (x *StaticCredentials) Reset() {
 	*x = StaticCredentials{}
-	mi := &file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -44,7 +44,7 @@ func (x *StaticCredentials) String() string {
 func (*StaticCredentials) ProtoMessage() {}
 
 func (x *StaticCredentials) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -57,7 +57,7 @@ func (x *StaticCredentials) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use StaticCredentials.ProtoReflect.Descriptor instead.
 func (*StaticCredentials) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *StaticCredentials) GetAccessKeyId() string {
@@ -84,7 +84,7 @@ type WebIdentityRoleCredentials struct {
 
 func (x *WebIdentityRoleCredentials) Reset() {
 	*x = WebIdentityRoleCredentials{}
-	mi := &file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -96,7 +96,7 @@ func (x *WebIdentityRoleCredentials) String() string {
 func (*WebIdentityRoleCredentials) ProtoMessage() {}
 
 func (x *WebIdentityRoleCredentials) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -109,7 +109,7 @@ func (x *WebIdentityRoleCredentials) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use WebIdentityRoleCredentials.ProtoReflect.Descriptor instead.
 func (*WebIdentityRoleCredentials) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *WebIdentityRoleCredentials) GetRoleArn() string {
@@ -141,7 +141,7 @@ type SessionConfiguration struct {
 
 func (x *SessionConfiguration) Reset() {
 	*x = SessionConfiguration{}
-	mi := &file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -153,7 +153,7 @@ func (x *SessionConfiguration) String() string {
 func (*SessionConfiguration) ProtoMessage() {}
 
 func (x *SessionConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -166,7 +166,7 @@ func (x *SessionConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SessionConfiguration.ProtoReflect.Descriptor instead.
 func (*SessionConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *SessionConfiguration) GetRegion() string {
@@ -224,11 +224,11 @@ func (*SessionConfiguration_StaticCredentials) isSessionConfiguration_Credential
 
 func (*SessionConfiguration_WebIdentityRoleCredentials) isSessionConfiguration_Credentials() {}
 
-var File_pkg_proto_configuration_cloud_aws_aws_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc = "" +
 	"\n" +
-	"+pkg/proto/configuration/cloud/aws/aws.proto\x12!buildbarn.configuration.cloud.aws\x1a0pkg/proto/configuration/http/client/client.proto\"c\n" +
+	"Kgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/aws/aws.proto\x12!buildbarn.configuration.cloud.aws\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\"c\n" +
 	"\x11StaticCredentials\x12\"\n" +
 	"\raccess_key_id\x18\x01 \x01(\tR\vaccessKeyId\x12*\n" +
 	"\x11secret_access_key\x18\x02 \x01(\tR\x0fsecretAccessKey\"V\n" +
@@ -245,25 +245,25 @@ const file_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc = "" +
 	"\vcredentialsJ\x04\b\x01\x10\x02J\x04\b\x03\x10\x04J\x04\b\x04\x10\x05BCZAgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/awsb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc), len(file_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_cloud_aws_aws_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_pkg_proto_configuration_cloud_aws_aws_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_goTypes = []any{
 	(*StaticCredentials)(nil),          // 0: buildbarn.configuration.cloud.aws.StaticCredentials
 	(*WebIdentityRoleCredentials)(nil), // 1: buildbarn.configuration.cloud.aws.WebIdentityRoleCredentials
 	(*SessionConfiguration)(nil),       // 2: buildbarn.configuration.cloud.aws.SessionConfiguration
 	(*client.Configuration)(nil),       // 3: buildbarn.configuration.http.client.Configuration
 }
-var file_pkg_proto_configuration_cloud_aws_aws_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_depIdxs = []int32{
 	0, // 0: buildbarn.configuration.cloud.aws.SessionConfiguration.static_credentials:type_name -> buildbarn.configuration.cloud.aws.StaticCredentials
 	1, // 1: buildbarn.configuration.cloud.aws.SessionConfiguration.web_identity_role_credentials:type_name -> buildbarn.configuration.cloud.aws.WebIdentityRoleCredentials
 	3, // 2: buildbarn.configuration.cloud.aws.SessionConfiguration.http_client:type_name -> buildbarn.configuration.http.client.Configuration
@@ -274,12 +274,12 @@ var file_pkg_proto_configuration_cloud_aws_aws_proto_depIdxs = []int32{
 	0, // [0:3] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_cloud_aws_aws_proto_init() }
-func file_pkg_proto_configuration_cloud_aws_aws_proto_init() {
-	if File_pkg_proto_configuration_cloud_aws_aws_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[2].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes[2].OneofWrappers = []any{
 		(*SessionConfiguration_StaticCredentials)(nil),
 		(*SessionConfiguration_WebIdentityRoleCredentials)(nil),
 	}
@@ -287,17 +287,17 @@ func file_pkg_proto_configuration_cloud_aws_aws_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc), len(file_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_cloud_aws_aws_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_cloud_aws_aws_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_cloud_aws_aws_proto = out.File
-	file_pkg_proto_configuration_cloud_aws_aws_proto_goTypes = nil
-	file_pkg_proto_configuration_cloud_aws_aws_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_aws_aws_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/cloud/aws/aws.proto
+++ b/pkg/proto/configuration/cloud/aws/aws.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package buildbarn.configuration.cloud.aws;
 
-import "pkg/proto/configuration/http/client/client.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/aws";
 

--- a/pkg/proto/configuration/cloud/gcp/BUILD.bazel
+++ b/pkg/proto/configuration/cloud/gcp/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "gcp_proto",
     srcs = ["gcp.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/proto/configuration/cloud/gcp/gcp.pb.go
+++ b/pkg/proto/configuration/cloud/gcp/gcp.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/cloud/gcp/gcp.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/gcp/gcp.proto
 
 package gcp
 
@@ -29,7 +29,7 @@ type ClientOptionsConfiguration struct {
 
 func (x *ClientOptionsConfiguration) Reset() {
 	*x = ClientOptionsConfiguration{}
-	mi := &file_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -41,7 +41,7 @@ func (x *ClientOptionsConfiguration) String() string {
 func (*ClientOptionsConfiguration) ProtoMessage() {}
 
 func (x *ClientOptionsConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -54,33 +54,33 @@ func (x *ClientOptionsConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientOptionsConfiguration.ProtoReflect.Descriptor instead.
 func (*ClientOptionsConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescGZIP(), []int{0}
 }
 
-var File_pkg_proto_configuration_cloud_gcp_gcp_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc = "" +
 	"\n" +
-	"+pkg/proto/configuration/cloud/gcp/gcp.proto\x12!buildbarn.configuration.cloud.gcp\"\x1c\n" +
+	"Kgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/gcp/gcp.proto\x12!buildbarn.configuration.cloud.gcp\"\x1c\n" +
 	"\x1aClientOptionsConfigurationBCZAgithub.com/buildbarn/bb-storage/pkg/proto/configuration/cloud/gcpb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc), len(file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_cloud_gcp_gcp_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_goTypes = []any{
 	(*ClientOptionsConfiguration)(nil), // 0: buildbarn.configuration.cloud.gcp.ClientOptionsConfiguration
 }
-var file_pkg_proto_configuration_cloud_gcp_gcp_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
@@ -88,26 +88,26 @@ var file_pkg_proto_configuration_cloud_gcp_gcp_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_cloud_gcp_gcp_proto_init() }
-func file_pkg_proto_configuration_cloud_gcp_gcp_proto_init() {
-	if File_pkg_proto_configuration_cloud_gcp_gcp_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc), len(file_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_cloud_gcp_gcp_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_cloud_gcp_gcp_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_cloud_gcp_gcp_proto = out.File
-	file_pkg_proto_configuration_cloud_gcp_gcp_proto_goTypes = nil
-	file_pkg_proto_configuration_cloud_gcp_gcp_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_cloud_gcp_gcp_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/digest/BUILD.bazel
+++ b/pkg/proto/configuration/digest/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "digest_proto",
     srcs = ["digest.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/eviction:eviction_proto",

--- a/pkg/proto/configuration/digest/digest.pb.go
+++ b/pkg/proto/configuration/digest/digest.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/digest/digest.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/digest/digest.proto
 
 package digest
 
@@ -34,7 +34,7 @@ type ExistenceCacheConfiguration struct {
 
 func (x *ExistenceCacheConfiguration) Reset() {
 	*x = ExistenceCacheConfiguration{}
-	mi := &file_pkg_proto_configuration_digest_digest_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -46,7 +46,7 @@ func (x *ExistenceCacheConfiguration) String() string {
 func (*ExistenceCacheConfiguration) ProtoMessage() {}
 
 func (x *ExistenceCacheConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_digest_digest_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59,7 +59,7 @@ func (x *ExistenceCacheConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ExistenceCacheConfiguration.ProtoReflect.Descriptor instead.
 func (*ExistenceCacheConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_digest_digest_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ExistenceCacheConfiguration) GetCacheSize() int64 {
@@ -83,11 +83,11 @@ func (x *ExistenceCacheConfiguration) GetCacheReplacementPolicy() eviction.Cache
 	return eviction.CacheReplacementPolicy(0)
 }
 
-var File_pkg_proto_configuration_digest_digest_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_digest_digest_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDesc = "" +
 	"\n" +
-	"+pkg/proto/configuration/digest/digest.proto\x12\x1ebuildbarn.configuration.digest\x1a\x1egoogle/protobuf/duration.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\"\xf2\x01\n" +
+	"Kgithub.com/buildbarn/bb-storage/pkg/proto/configuration/digest/digest.proto\x12\x1ebuildbarn.configuration.digest\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto\x1a\x1egoogle/protobuf/duration.proto\"\xf2\x01\n" +
 	"\x1bExistenceCacheConfiguration\x12\x1d\n" +
 	"\n" +
 	"cache_size\x18\x01 \x01(\x03R\tcacheSize\x12@\n" +
@@ -95,24 +95,24 @@ const file_pkg_proto_configuration_digest_digest_proto_rawDesc = "" +
 	"\x18cache_replacement_policy\x18\x03 \x01(\x0e28.buildbarn.configuration.eviction.CacheReplacementPolicyR\x16cacheReplacementPolicyB@Z>github.com/buildbarn/bb-storage/pkg/proto/configuration/digestb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_digest_digest_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_digest_digest_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_digest_digest_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_digest_digest_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_digest_digest_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_digest_digest_proto_rawDesc), len(file_pkg_proto_configuration_digest_digest_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_digest_digest_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_digest_digest_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_digest_digest_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_goTypes = []any{
 	(*ExistenceCacheConfiguration)(nil),  // 0: buildbarn.configuration.digest.ExistenceCacheConfiguration
 	(*durationpb.Duration)(nil),          // 1: google.protobuf.Duration
 	(eviction.CacheReplacementPolicy)(0), // 2: buildbarn.configuration.eviction.CacheReplacementPolicy
 }
-var file_pkg_proto_configuration_digest_digest_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.digest.ExistenceCacheConfiguration.cache_duration:type_name -> google.protobuf.Duration
 	2, // 1: buildbarn.configuration.digest.ExistenceCacheConfiguration.cache_replacement_policy:type_name -> buildbarn.configuration.eviction.CacheReplacementPolicy
 	2, // [2:2] is the sub-list for method output_type
@@ -122,26 +122,26 @@ var file_pkg_proto_configuration_digest_digest_proto_depIdxs = []int32{
 	0, // [0:2] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_digest_digest_proto_init() }
-func file_pkg_proto_configuration_digest_digest_proto_init() {
-	if File_pkg_proto_configuration_digest_digest_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_digest_digest_proto_rawDesc), len(file_pkg_proto_configuration_digest_digest_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_digest_digest_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_digest_digest_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_digest_digest_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_digest_digest_proto = out.File
-	file_pkg_proto_configuration_digest_digest_proto_goTypes = nil
-	file_pkg_proto_configuration_digest_digest_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_digest_digest_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/digest/digest.proto
+++ b/pkg/proto/configuration/digest/digest.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package buildbarn.configuration.digest;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto";
 import "google/protobuf/duration.proto";
-import "pkg/proto/configuration/eviction/eviction.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/digest";
 

--- a/pkg/proto/configuration/eviction/BUILD.bazel
+++ b/pkg/proto/configuration/eviction/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "eviction_proto",
     srcs = ["eviction.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
 )
 

--- a/pkg/proto/configuration/eviction/eviction.pb.go
+++ b/pkg/proto/configuration/eviction/eviction.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/eviction/eviction.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto
 
 package eviction
 
@@ -57,11 +57,11 @@ func (x CacheReplacementPolicy) String() string {
 }
 
 func (CacheReplacementPolicy) Descriptor() protoreflect.EnumDescriptor {
-	return file_pkg_proto_configuration_eviction_eviction_proto_enumTypes[0].Descriptor()
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_enumTypes[0].Descriptor()
 }
 
 func (CacheReplacementPolicy) Type() protoreflect.EnumType {
-	return &file_pkg_proto_configuration_eviction_eviction_proto_enumTypes[0]
+	return &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_enumTypes[0]
 }
 
 func (x CacheReplacementPolicy) Number() protoreflect.EnumNumber {
@@ -70,14 +70,14 @@ func (x CacheReplacementPolicy) Number() protoreflect.EnumNumber {
 
 // Deprecated: Use CacheReplacementPolicy.Descriptor instead.
 func (CacheReplacementPolicy) EnumDescriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_eviction_eviction_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDescGZIP(), []int{0}
 }
 
-var File_pkg_proto_configuration_eviction_eviction_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_eviction_eviction_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDesc = "" +
 	"\n" +
-	"/pkg/proto/configuration/eviction/eviction.proto\x12 buildbarn.configuration.eviction*n\n" +
+	"Ogithub.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto\x12 buildbarn.configuration.eviction*n\n" +
 	"\x16CacheReplacementPolicy\x12\v\n" +
 	"\aUNKNOWN\x10\x00\x12\x16\n" +
 	"\x12FIRST_IN_FIRST_OUT\x10\x01\x12\x17\n" +
@@ -85,22 +85,22 @@ const file_pkg_proto_configuration_eviction_eviction_proto_rawDesc = "" +
 	"\x12RANDOM_REPLACEMENT\x10\x03BBZ@github.com/buildbarn/bb-storage/pkg/proto/configuration/evictionb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_eviction_eviction_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_eviction_eviction_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_eviction_eviction_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_eviction_eviction_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_eviction_eviction_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_eviction_eviction_proto_rawDesc), len(file_pkg_proto_configuration_eviction_eviction_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_eviction_eviction_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_eviction_eviction_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_pkg_proto_configuration_eviction_eviction_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_goTypes = []any{
 	(CacheReplacementPolicy)(0), // 0: buildbarn.configuration.eviction.CacheReplacementPolicy
 }
-var file_pkg_proto_configuration_eviction_eviction_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for method output_type
 	0, // [0:0] is the sub-list for method input_type
 	0, // [0:0] is the sub-list for extension type_name
@@ -108,26 +108,28 @@ var file_pkg_proto_configuration_eviction_eviction_proto_depIdxs = []int32{
 	0, // [0:0] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_eviction_eviction_proto_init() }
-func file_pkg_proto_configuration_eviction_eviction_proto_init() {
-	if File_pkg_proto_configuration_eviction_eviction_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_eviction_eviction_proto_rawDesc), len(file_pkg_proto_configuration_eviction_eviction_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_rawDesc)),
 			NumEnums:      1,
 			NumMessages:   0,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_eviction_eviction_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_eviction_eviction_proto_depIdxs,
-		EnumInfos:         file_pkg_proto_configuration_eviction_eviction_proto_enumTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_depIdxs,
+		EnumInfos:         file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_enumTypes,
 	}.Build()
-	File_pkg_proto_configuration_eviction_eviction_proto = out.File
-	file_pkg_proto_configuration_eviction_eviction_proto_goTypes = nil
-	file_pkg_proto_configuration_eviction_eviction_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_eviction_eviction_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/global/BUILD.bazel
+++ b/pkg/proto/configuration/global/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "global_proto",
     srcs = ["global.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/grpc:grpc_proto",

--- a/pkg/proto/configuration/global/global.pb.go
+++ b/pkg/proto/configuration/global/global.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/global/global.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/global/global.proto
 
 package global
 
@@ -43,7 +43,7 @@ type PrometheusPushgatewayConfiguration struct {
 
 func (x *PrometheusPushgatewayConfiguration) Reset() {
 	*x = PrometheusPushgatewayConfiguration{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -55,7 +55,7 @@ func (x *PrometheusPushgatewayConfiguration) String() string {
 func (*PrometheusPushgatewayConfiguration) ProtoMessage() {}
 
 func (x *PrometheusPushgatewayConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -68,7 +68,7 @@ func (x *PrometheusPushgatewayConfiguration) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use PrometheusPushgatewayConfiguration.ProtoReflect.Descriptor instead.
 func (*PrometheusPushgatewayConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *PrometheusPushgatewayConfiguration) GetUrl() string {
@@ -131,7 +131,7 @@ type TracingConfiguration struct {
 
 func (x *TracingConfiguration) Reset() {
 	*x = TracingConfiguration{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -143,7 +143,7 @@ func (x *TracingConfiguration) String() string {
 func (*TracingConfiguration) ProtoMessage() {}
 
 func (x *TracingConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -156,7 +156,7 @@ func (x *TracingConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracingConfiguration.ProtoReflect.Descriptor instead.
 func (*TracingConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *TracingConfiguration) GetBackends() []*TracingConfiguration_Backend {
@@ -189,7 +189,7 @@ type SetUmaskConfiguration struct {
 
 func (x *SetUmaskConfiguration) Reset() {
 	*x = SetUmaskConfiguration{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -201,7 +201,7 @@ func (x *SetUmaskConfiguration) String() string {
 func (*SetUmaskConfiguration) ProtoMessage() {}
 
 func (x *SetUmaskConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -214,7 +214,7 @@ func (x *SetUmaskConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetUmaskConfiguration.ProtoReflect.Descriptor instead.
 func (*SetUmaskConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *SetUmaskConfiguration) GetUmask() uint32 {
@@ -234,7 +234,7 @@ type SetResourceLimitConfiguration struct {
 
 func (x *SetResourceLimitConfiguration) Reset() {
 	*x = SetResourceLimitConfiguration{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +246,7 @@ func (x *SetResourceLimitConfiguration) String() string {
 func (*SetResourceLimitConfiguration) ProtoMessage() {}
 
 func (x *SetResourceLimitConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -259,7 +259,7 @@ func (x *SetResourceLimitConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetResourceLimitConfiguration.ProtoReflect.Descriptor instead.
 func (*SetResourceLimitConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{3}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *SetResourceLimitConfiguration) GetSoftLimit() *wrapperspb.UInt64Value {
@@ -293,7 +293,7 @@ type Configuration struct {
 
 func (x *Configuration) Reset() {
 	*x = Configuration{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -305,7 +305,7 @@ func (x *Configuration) String() string {
 func (*Configuration) ProtoMessage() {}
 
 func (x *Configuration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -318,7 +318,7 @@ func (x *Configuration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Configuration.ProtoReflect.Descriptor instead.
 func (*Configuration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{4}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *Configuration) GetTracing() *TracingConfiguration {
@@ -396,7 +396,7 @@ type DiagnosticsHTTPServerConfiguration struct {
 
 func (x *DiagnosticsHTTPServerConfiguration) Reset() {
 	*x = DiagnosticsHTTPServerConfiguration{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -408,7 +408,7 @@ func (x *DiagnosticsHTTPServerConfiguration) String() string {
 func (*DiagnosticsHTTPServerConfiguration) ProtoMessage() {}
 
 func (x *DiagnosticsHTTPServerConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -421,7 +421,7 @@ func (x *DiagnosticsHTTPServerConfiguration) ProtoReflect() protoreflect.Message
 
 // Deprecated: Use DiagnosticsHTTPServerConfiguration.ProtoReflect.Descriptor instead.
 func (*DiagnosticsHTTPServerConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{5}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *DiagnosticsHTTPServerConfiguration) GetHttpServers() []*server.Configuration {
@@ -462,7 +462,7 @@ type GRPCKubernetesResolver struct {
 
 func (x *GRPCKubernetesResolver) Reset() {
 	*x = GRPCKubernetesResolver{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -474,7 +474,7 @@ func (x *GRPCKubernetesResolver) String() string {
 func (*GRPCKubernetesResolver) ProtoMessage() {}
 
 func (x *GRPCKubernetesResolver) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -487,7 +487,7 @@ func (x *GRPCKubernetesResolver) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GRPCKubernetesResolver.ProtoReflect.Descriptor instead.
 func (*GRPCKubernetesResolver) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{6}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *GRPCKubernetesResolver) GetApiServerHttpClient() *client.Configuration {
@@ -515,7 +515,7 @@ type PrometheusPushgatewayConfiguration_AdditionalScrapeTarget struct {
 
 func (x *PrometheusPushgatewayConfiguration_AdditionalScrapeTarget) Reset() {
 	*x = PrometheusPushgatewayConfiguration_AdditionalScrapeTarget{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[8]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -527,7 +527,7 @@ func (x *PrometheusPushgatewayConfiguration_AdditionalScrapeTarget) String() str
 func (*PrometheusPushgatewayConfiguration_AdditionalScrapeTarget) ProtoMessage() {}
 
 func (x *PrometheusPushgatewayConfiguration_AdditionalScrapeTarget) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[8]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -540,7 +540,7 @@ func (x *PrometheusPushgatewayConfiguration_AdditionalScrapeTarget) ProtoReflect
 
 // Deprecated: Use PrometheusPushgatewayConfiguration_AdditionalScrapeTarget.ProtoReflect.Descriptor instead.
 func (*PrometheusPushgatewayConfiguration_AdditionalScrapeTarget) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{0, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{0, 1}
 }
 
 func (x *PrometheusPushgatewayConfiguration_AdditionalScrapeTarget) GetHttpClient() *client.Configuration {
@@ -582,7 +582,7 @@ type TracingConfiguration_Backend struct {
 
 func (x *TracingConfiguration_Backend) Reset() {
 	*x = TracingConfiguration_Backend{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[9]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -594,7 +594,7 @@ func (x *TracingConfiguration_Backend) String() string {
 func (*TracingConfiguration_Backend) ProtoMessage() {}
 
 func (x *TracingConfiguration_Backend) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[9]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -607,7 +607,7 @@ func (x *TracingConfiguration_Backend) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracingConfiguration_Backend.ProtoReflect.Descriptor instead.
 func (*TracingConfiguration_Backend) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 0}
 }
 
 func (x *TracingConfiguration_Backend) GetSpanExporter() isTracingConfiguration_Backend_SpanExporter {
@@ -711,7 +711,7 @@ type TracingConfiguration_Sampler struct {
 
 func (x *TracingConfiguration_Sampler) Reset() {
 	*x = TracingConfiguration_Sampler{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[10]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -723,7 +723,7 @@ func (x *TracingConfiguration_Sampler) String() string {
 func (*TracingConfiguration_Sampler) ProtoMessage() {}
 
 func (x *TracingConfiguration_Sampler) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[10]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -736,7 +736,7 @@ func (x *TracingConfiguration_Sampler) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracingConfiguration_Sampler.ProtoReflect.Descriptor instead.
 func (*TracingConfiguration_Sampler) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 1}
 }
 
 func (x *TracingConfiguration_Sampler) GetPolicy() isTracingConfiguration_Sampler_Policy {
@@ -837,7 +837,7 @@ type TracingConfiguration_Backend_JaegerCollectorSpanExporter struct {
 
 func (x *TracingConfiguration_Backend_JaegerCollectorSpanExporter) Reset() {
 	*x = TracingConfiguration_Backend_JaegerCollectorSpanExporter{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[11]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -849,7 +849,7 @@ func (x *TracingConfiguration_Backend_JaegerCollectorSpanExporter) String() stri
 func (*TracingConfiguration_Backend_JaegerCollectorSpanExporter) ProtoMessage() {}
 
 func (x *TracingConfiguration_Backend_JaegerCollectorSpanExporter) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[11]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -862,7 +862,7 @@ func (x *TracingConfiguration_Backend_JaegerCollectorSpanExporter) ProtoReflect(
 
 // Deprecated: Use TracingConfiguration_Backend_JaegerCollectorSpanExporter.ProtoReflect.Descriptor instead.
 func (*TracingConfiguration_Backend_JaegerCollectorSpanExporter) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 0, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 0, 0}
 }
 
 func (x *TracingConfiguration_Backend_JaegerCollectorSpanExporter) GetEndpoint() string {
@@ -906,7 +906,7 @@ type TracingConfiguration_Backend_BatchSpanProcessor struct {
 
 func (x *TracingConfiguration_Backend_BatchSpanProcessor) Reset() {
 	*x = TracingConfiguration_Backend_BatchSpanProcessor{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[12]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[12]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -918,7 +918,7 @@ func (x *TracingConfiguration_Backend_BatchSpanProcessor) String() string {
 func (*TracingConfiguration_Backend_BatchSpanProcessor) ProtoMessage() {}
 
 func (x *TracingConfiguration_Backend_BatchSpanProcessor) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[12]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[12]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -931,7 +931,7 @@ func (x *TracingConfiguration_Backend_BatchSpanProcessor) ProtoReflect() protore
 
 // Deprecated: Use TracingConfiguration_Backend_BatchSpanProcessor.ProtoReflect.Descriptor instead.
 func (*TracingConfiguration_Backend_BatchSpanProcessor) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 0, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 0, 1}
 }
 
 func (x *TracingConfiguration_Backend_BatchSpanProcessor) GetBatchTimeout() *durationpb.Duration {
@@ -982,7 +982,7 @@ type TracingConfiguration_Sampler_ParentBased struct {
 
 func (x *TracingConfiguration_Sampler_ParentBased) Reset() {
 	*x = TracingConfiguration_Sampler_ParentBased{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[13]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[13]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -994,7 +994,7 @@ func (x *TracingConfiguration_Sampler_ParentBased) String() string {
 func (*TracingConfiguration_Sampler_ParentBased) ProtoMessage() {}
 
 func (x *TracingConfiguration_Sampler_ParentBased) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[13]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[13]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1007,7 +1007,7 @@ func (x *TracingConfiguration_Sampler_ParentBased) ProtoReflect() protoreflect.M
 
 // Deprecated: Use TracingConfiguration_Sampler_ParentBased.ProtoReflect.Descriptor instead.
 func (*TracingConfiguration_Sampler_ParentBased) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 1, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 1, 0}
 }
 
 func (x *TracingConfiguration_Sampler_ParentBased) GetNoParent() *TracingConfiguration_Sampler {
@@ -1055,7 +1055,7 @@ type TracingConfiguration_Sampler_MaximumRate struct {
 
 func (x *TracingConfiguration_Sampler_MaximumRate) Reset() {
 	*x = TracingConfiguration_Sampler_MaximumRate{}
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[14]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[14]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1067,7 +1067,7 @@ func (x *TracingConfiguration_Sampler_MaximumRate) String() string {
 func (*TracingConfiguration_Sampler_MaximumRate) ProtoMessage() {}
 
 func (x *TracingConfiguration_Sampler_MaximumRate) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_global_global_proto_msgTypes[14]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[14]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1080,7 +1080,7 @@ func (x *TracingConfiguration_Sampler_MaximumRate) ProtoReflect() protoreflect.M
 
 // Deprecated: Use TracingConfiguration_Sampler_MaximumRate.ProtoReflect.Descriptor instead.
 func (*TracingConfiguration_Sampler_MaximumRate) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 1, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP(), []int{1, 1, 1}
 }
 
 func (x *TracingConfiguration_Sampler_MaximumRate) GetSamplesPerEpoch() int64 {
@@ -1097,11 +1097,11 @@ func (x *TracingConfiguration_Sampler_MaximumRate) GetEpochDuration() *durationp
 	return nil
 }
 
-var File_pkg_proto_configuration_global_global_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_global_global_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDesc = "" +
 	"\n" +
-	"+pkg/proto/configuration/global/global.proto\x12\x1ebuildbarn.configuration.global\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a*opentelemetry/proto/common/v1/common.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\x1a0pkg/proto/configuration/http/server/server.proto\x1a0pkg/proto/configuration/http/client/client.proto\"\x96\x06\n" +
+	"Kgithub.com/buildbarn/bb-storage/pkg/proto/configuration/global/global.proto\x12\x1ebuildbarn.configuration.global\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/server/server.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a*opentelemetry/proto/common/v1/common.proto\"\x96\x06\n" +
 	"\"PrometheusPushgatewayConfiguration\x12\x10\n" +
 	"\x03url\x18\x01 \x01(\tR\x03url\x12\x10\n" +
 	"\x03job\x18\x02 \x01(\tR\x03job\x12l\n" +
@@ -1191,19 +1191,19 @@ const file_pkg_proto_configuration_global_global_proto_rawDesc = "" +
 	"\x0eapi_server_url\x18\x02 \x01(\tR\fapiServerUrlB@Z>github.com/buildbarn/bb-storage/pkg/proto/configuration/globalb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_global_global_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_global_global_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_global_global_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_global_global_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_global_global_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_global_global_proto_rawDesc), len(file_pkg_proto_configuration_global_global_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_global_global_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_global_global_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
-var file_pkg_proto_configuration_global_global_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_goTypes = []any{
 	(*PrometheusPushgatewayConfiguration)(nil), // 0: buildbarn.configuration.global.PrometheusPushgatewayConfiguration
 	(*TracingConfiguration)(nil),               // 1: buildbarn.configuration.global.TracingConfiguration
 	(*SetUmaskConfiguration)(nil),              // 2: buildbarn.configuration.global.SetUmaskConfiguration
@@ -1229,7 +1229,7 @@ var file_pkg_proto_configuration_global_global_proto_goTypes = []any{
 	(*grpc.ClientConfiguration)(nil), // 22: buildbarn.configuration.grpc.ClientConfiguration
 	(*emptypb.Empty)(nil),            // 23: google.protobuf.Empty
 }
-var file_pkg_proto_configuration_global_global_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_depIdxs = []int32{
 	7,  // 0: buildbarn.configuration.global.PrometheusPushgatewayConfiguration.grouping:type_name -> buildbarn.configuration.global.PrometheusPushgatewayConfiguration.GroupingEntry
 	17, // 1: buildbarn.configuration.global.PrometheusPushgatewayConfiguration.push_interval:type_name -> google.protobuf.Duration
 	18, // 2: buildbarn.configuration.global.PrometheusPushgatewayConfiguration.http_client:type_name -> buildbarn.configuration.http.client.Configuration
@@ -1275,18 +1275,18 @@ var file_pkg_proto_configuration_global_global_proto_depIdxs = []int32{
 	0,  // [0:38] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_global_global_proto_init() }
-func file_pkg_proto_configuration_global_global_proto_init() {
-	if File_pkg_proto_configuration_global_global_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_global_global_proto_msgTypes[9].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[9].OneofWrappers = []any{
 		(*TracingConfiguration_Backend_JaegerCollectorSpanExporter_)(nil),
 		(*TracingConfiguration_Backend_OtlpSpanExporter)(nil),
 		(*TracingConfiguration_Backend_SimpleSpanProcessor)(nil),
 		(*TracingConfiguration_Backend_BatchSpanProcessor_)(nil),
 	}
-	file_pkg_proto_configuration_global_global_proto_msgTypes[10].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes[10].OneofWrappers = []any{
 		(*TracingConfiguration_Sampler_Always)(nil),
 		(*TracingConfiguration_Sampler_Never)(nil),
 		(*TracingConfiguration_Sampler_ParentBased_)(nil),
@@ -1297,17 +1297,17 @@ func file_pkg_proto_configuration_global_global_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_global_global_proto_rawDesc), len(file_pkg_proto_configuration_global_global_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   17,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_global_global_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_global_global_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_global_global_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_global_global_proto = out.File
-	file_pkg_proto_configuration_global_global_proto_goTypes = nil
-	file_pkg_proto_configuration_global_global_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_global_global_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/global/global.proto
+++ b/pkg/proto/configuration/global/global.proto
@@ -2,13 +2,13 @@ syntax = "proto3";
 
 package buildbarn.configuration.global;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/server/server.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/wrappers.proto";
 import "opentelemetry/proto/common/v1/common.proto";
-import "pkg/proto/configuration/grpc/grpc.proto";
-import "pkg/proto/configuration/http/server/server.proto";
-import "pkg/proto/configuration/http/client/client.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/global";
 

--- a/pkg/proto/configuration/grpc/BUILD.bazel
+++ b/pkg/proto/configuration/grpc/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "grpc_proto",
     srcs = ["grpc.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/auth:auth_proto",

--- a/pkg/proto/configuration/grpc/grpc.pb.go
+++ b/pkg/proto/configuration/grpc/grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/grpc/grpc.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto
 
 package grpc
 
@@ -49,7 +49,7 @@ type ClientConfiguration struct {
 
 func (x *ClientConfiguration) Reset() {
 	*x = ClientConfiguration{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -61,7 +61,7 @@ func (x *ClientConfiguration) String() string {
 func (*ClientConfiguration) ProtoMessage() {}
 
 func (x *ClientConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -74,7 +74,7 @@ func (x *ClientConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientConfiguration.ProtoReflect.Descriptor instead.
 func (*ClientConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ClientConfiguration) GetAddress() string {
@@ -165,7 +165,7 @@ type ClientKeepaliveConfiguration struct {
 
 func (x *ClientKeepaliveConfiguration) Reset() {
 	*x = ClientKeepaliveConfiguration{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -177,7 +177,7 @@ func (x *ClientKeepaliveConfiguration) String() string {
 func (*ClientKeepaliveConfiguration) ProtoMessage() {}
 
 func (x *ClientKeepaliveConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -190,7 +190,7 @@ func (x *ClientKeepaliveConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientKeepaliveConfiguration.ProtoReflect.Descriptor instead.
 func (*ClientKeepaliveConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *ClientKeepaliveConfiguration) GetTime() *durationpb.Duration {
@@ -234,7 +234,7 @@ type ServerConfiguration struct {
 
 func (x *ServerConfiguration) Reset() {
 	*x = ServerConfiguration{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +246,7 @@ func (x *ServerConfiguration) String() string {
 func (*ServerConfiguration) ProtoMessage() {}
 
 func (x *ServerConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -259,7 +259,7 @@ func (x *ServerConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerConfiguration.ProtoReflect.Descriptor instead.
 func (*ServerConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *ServerConfiguration) GetListenAddresses() []string {
@@ -356,7 +356,7 @@ type ServerKeepaliveEnforcementPolicy struct {
 
 func (x *ServerKeepaliveEnforcementPolicy) Reset() {
 	*x = ServerKeepaliveEnforcementPolicy{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -368,7 +368,7 @@ func (x *ServerKeepaliveEnforcementPolicy) String() string {
 func (*ServerKeepaliveEnforcementPolicy) ProtoMessage() {}
 
 func (x *ServerKeepaliveEnforcementPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -381,7 +381,7 @@ func (x *ServerKeepaliveEnforcementPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerKeepaliveEnforcementPolicy.ProtoReflect.Descriptor instead.
 func (*ServerKeepaliveEnforcementPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{3}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *ServerKeepaliveEnforcementPolicy) GetMinTime() *durationpb.Duration {
@@ -411,7 +411,7 @@ type ServerKeepaliveParameters struct {
 
 func (x *ServerKeepaliveParameters) Reset() {
 	*x = ServerKeepaliveParameters{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -423,7 +423,7 @@ func (x *ServerKeepaliveParameters) String() string {
 func (*ServerKeepaliveParameters) ProtoMessage() {}
 
 func (x *ServerKeepaliveParameters) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -436,7 +436,7 @@ func (x *ServerKeepaliveParameters) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerKeepaliveParameters.ProtoReflect.Descriptor instead.
 func (*ServerKeepaliveParameters) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{4}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *ServerKeepaliveParameters) GetMaxConnectionIdle() *durationpb.Duration {
@@ -493,7 +493,7 @@ type AuthenticationPolicy struct {
 
 func (x *AuthenticationPolicy) Reset() {
 	*x = AuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -505,7 +505,7 @@ func (x *AuthenticationPolicy) String() string {
 func (*AuthenticationPolicy) ProtoMessage() {}
 
 func (x *AuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -518,7 +518,7 @@ func (x *AuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*AuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{5}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{5}
 }
 
 func (x *AuthenticationPolicy) GetPolicy() isAuthenticationPolicy_Policy {
@@ -661,7 +661,7 @@ type AnyAuthenticationPolicy struct {
 
 func (x *AnyAuthenticationPolicy) Reset() {
 	*x = AnyAuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -673,7 +673,7 @@ func (x *AnyAuthenticationPolicy) String() string {
 func (*AnyAuthenticationPolicy) ProtoMessage() {}
 
 func (x *AnyAuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -686,7 +686,7 @@ func (x *AnyAuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AnyAuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*AnyAuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{6}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{6}
 }
 
 func (x *AnyAuthenticationPolicy) GetPolicies() []*AuthenticationPolicy {
@@ -705,7 +705,7 @@ type AllAuthenticationPolicy struct {
 
 func (x *AllAuthenticationPolicy) Reset() {
 	*x = AllAuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[7]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[7]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -717,7 +717,7 @@ func (x *AllAuthenticationPolicy) String() string {
 func (*AllAuthenticationPolicy) ProtoMessage() {}
 
 func (x *AllAuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[7]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[7]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -730,7 +730,7 @@ func (x *AllAuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AllAuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*AllAuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{7}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{7}
 }
 
 func (x *AllAuthenticationPolicy) GetPolicies() []*AuthenticationPolicy {
@@ -751,7 +751,7 @@ type TLSClientCertificateAuthenticationPolicy struct {
 
 func (x *TLSClientCertificateAuthenticationPolicy) Reset() {
 	*x = TLSClientCertificateAuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[8]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[8]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -763,7 +763,7 @@ func (x *TLSClientCertificateAuthenticationPolicy) String() string {
 func (*TLSClientCertificateAuthenticationPolicy) ProtoMessage() {}
 
 func (x *TLSClientCertificateAuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[8]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[8]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -776,7 +776,7 @@ func (x *TLSClientCertificateAuthenticationPolicy) ProtoReflect() protoreflect.M
 
 // Deprecated: Use TLSClientCertificateAuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*TLSClientCertificateAuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{8}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{8}
 }
 
 func (x *TLSClientCertificateAuthenticationPolicy) GetClientCertificateAuthorities() string {
@@ -813,7 +813,7 @@ type RemoteAuthenticationPolicy struct {
 
 func (x *RemoteAuthenticationPolicy) Reset() {
 	*x = RemoteAuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[9]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[9]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -825,7 +825,7 @@ func (x *RemoteAuthenticationPolicy) String() string {
 func (*RemoteAuthenticationPolicy) ProtoMessage() {}
 
 func (x *RemoteAuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[9]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[9]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -838,7 +838,7 @@ func (x *RemoteAuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use RemoteAuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*RemoteAuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{9}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{9}
 }
 
 func (x *RemoteAuthenticationPolicy) GetHeaders() []string {
@@ -886,7 +886,7 @@ type TracingMethodConfiguration struct {
 
 func (x *TracingMethodConfiguration) Reset() {
 	*x = TracingMethodConfiguration{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[10]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[10]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -898,7 +898,7 @@ func (x *TracingMethodConfiguration) String() string {
 func (*TracingMethodConfiguration) ProtoMessage() {}
 
 func (x *TracingMethodConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[10]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[10]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -911,7 +911,7 @@ func (x *TracingMethodConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TracingMethodConfiguration.ProtoReflect.Descriptor instead.
 func (*TracingMethodConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{10}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{10}
 }
 
 func (x *TracingMethodConfiguration) GetAttributesFromFirstRequestMessage() []string {
@@ -938,7 +938,7 @@ type ClientConfiguration_HeaderValues struct {
 
 func (x *ClientConfiguration_HeaderValues) Reset() {
 	*x = ClientConfiguration_HeaderValues{}
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[11]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[11]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -950,7 +950,7 @@ func (x *ClientConfiguration_HeaderValues) String() string {
 func (*ClientConfiguration_HeaderValues) ProtoMessage() {}
 
 func (x *ClientConfiguration_HeaderValues) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[11]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[11]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -963,7 +963,7 @@ func (x *ClientConfiguration_HeaderValues) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientConfiguration_HeaderValues.ProtoReflect.Descriptor instead.
 func (*ClientConfiguration_HeaderValues) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{0, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP(), []int{0, 0}
 }
 
 func (x *ClientConfiguration_HeaderValues) GetHeader() string {
@@ -980,11 +980,11 @@ func (x *ClientConfiguration_HeaderValues) GetValues() []string {
 	return nil
 }
 
-var File_pkg_proto_configuration_grpc_grpc_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_grpc_grpc_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDesc = "" +
 	"\n" +
-	"'pkg/proto/configuration/grpc/grpc.proto\x12\x1cbuildbarn.configuration.grpc\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x19pkg/proto/auth/auth.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\x1a0pkg/proto/configuration/http/client/client.proto\x1a%pkg/proto/configuration/jwt/jwt.proto\x1a%pkg/proto/configuration/tls/tls.proto\x1a'pkg/proto/configuration/x509/x509.proto\x1a/pkg/proto/configuration/jmespath/jmespath.proto\"\x80\b\n" +
+	"Ggithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\x12\x1cbuildbarn.configuration.grpc\x1a9github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto\x1aEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/jwt/jwt.proto\x1aEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/x509/x509.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1cgoogle/protobuf/struct.proto\"\x80\b\n" +
 	"\x13ClientConfiguration\x12\x18\n" +
 	"\aaddress\x18\x01 \x01(\tR\aaddress\x12B\n" +
 	"\x03tls\x18\x02 \x01(\v20.buildbarn.configuration.tls.ClientConfigurationR\x03tls\x12X\n" +
@@ -1063,19 +1063,19 @@ const file_pkg_proto_configuration_grpc_grpc_proto_rawDesc = "" +
 	"&attributes_from_first_response_message\x18\x02 \x03(\tR\"attributesFromFirstResponseMessageB>Z<github.com/buildbarn/bb-storage/pkg/proto/configuration/grpcb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_grpc_grpc_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_grpc_grpc_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_grpc_grpc_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_grpc_grpc_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_grpc_grpc_proto_rawDesc), len(file_pkg_proto_configuration_grpc_grpc_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_grpc_grpc_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_grpc_grpc_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
-var file_pkg_proto_configuration_grpc_grpc_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes = make([]protoimpl.MessageInfo, 14)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_goTypes = []any{
 	(*ClientConfiguration)(nil),                         // 0: buildbarn.configuration.grpc.ClientConfiguration
 	(*ClientKeepaliveConfiguration)(nil),                // 1: buildbarn.configuration.grpc.ClientKeepaliveConfiguration
 	(*ServerConfiguration)(nil),                         // 2: buildbarn.configuration.grpc.ServerConfiguration
@@ -1102,7 +1102,7 @@ var file_pkg_proto_configuration_grpc_grpc_proto_goTypes = []any{
 	(*structpb.Value)(nil),                              // 23: google.protobuf.Value
 	(eviction.CacheReplacementPolicy)(0),                // 24: buildbarn.configuration.eviction.CacheReplacementPolicy
 }
-var file_pkg_proto_configuration_grpc_grpc_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_depIdxs = []int32{
 	14, // 0: buildbarn.configuration.grpc.ClientConfiguration.tls:type_name -> buildbarn.configuration.tls.ClientConfiguration
 	1,  // 1: buildbarn.configuration.grpc.ClientConfiguration.keepalive:type_name -> buildbarn.configuration.grpc.ClientKeepaliveConfiguration
 	11, // 2: buildbarn.configuration.grpc.ClientConfiguration.add_metadata:type_name -> buildbarn.configuration.grpc.ClientConfiguration.HeaderValues
@@ -1146,12 +1146,12 @@ var file_pkg_proto_configuration_grpc_grpc_proto_depIdxs = []int32{
 	0,  // [0:36] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_grpc_grpc_proto_init() }
-func file_pkg_proto_configuration_grpc_grpc_proto_init() {
-	if File_pkg_proto_configuration_grpc_grpc_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_grpc_grpc_proto_msgTypes[5].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes[5].OneofWrappers = []any{
 		(*AuthenticationPolicy_Allow)(nil),
 		(*AuthenticationPolicy_Any)(nil),
 		(*AuthenticationPolicy_All)(nil),
@@ -1165,17 +1165,17 @@ func file_pkg_proto_configuration_grpc_grpc_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_grpc_grpc_proto_rawDesc), len(file_pkg_proto_configuration_grpc_grpc_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   14,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_grpc_grpc_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_grpc_grpc_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_grpc_grpc_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_grpc_grpc_proto = out.File
-	file_pkg_proto_configuration_grpc_grpc_proto_goTypes = nil
-	file_pkg_proto_configuration_grpc_grpc_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_grpc_grpc_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/grpc/grpc.proto
+++ b/pkg/proto/configuration/grpc/grpc.proto
@@ -2,15 +2,15 @@ syntax = "proto3";
 
 package buildbarn.configuration.grpc;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/jwt/jwt.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/x509/x509.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/struct.proto";
-import "pkg/proto/auth/auth.proto";
-import "pkg/proto/configuration/eviction/eviction.proto";
-import "pkg/proto/configuration/http/client/client.proto";
-import "pkg/proto/configuration/jwt/jwt.proto";
-import "pkg/proto/configuration/tls/tls.proto";
-import "pkg/proto/configuration/x509/x509.proto";
-import "pkg/proto/configuration/jmespath/jmespath.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc";
 

--- a/pkg/proto/configuration/http/client/BUILD.bazel
+++ b/pkg/proto/configuration/http/client/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "client_proto",
     srcs = ["client.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/tls:tls_proto",

--- a/pkg/proto/configuration/http/client/client.pb.go
+++ b/pkg/proto/configuration/http/client/client.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/http/client/client.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto
 
 package client
 
@@ -36,7 +36,7 @@ type Configuration struct {
 
 func (x *Configuration) Reset() {
 	*x = Configuration{}
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -48,7 +48,7 @@ func (x *Configuration) String() string {
 func (*Configuration) ProtoMessage() {}
 
 func (x *Configuration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -61,7 +61,7 @@ func (x *Configuration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Configuration.ProtoReflect.Descriptor instead.
 func (*Configuration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *Configuration) GetTls() *tls.ClientConfiguration {
@@ -114,7 +114,7 @@ type OAuth2Configuration struct {
 
 func (x *OAuth2Configuration) Reset() {
 	*x = OAuth2Configuration{}
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -126,7 +126,7 @@ func (x *OAuth2Configuration) String() string {
 func (*OAuth2Configuration) ProtoMessage() {}
 
 func (x *OAuth2Configuration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -139,7 +139,7 @@ func (x *OAuth2Configuration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OAuth2Configuration.ProtoReflect.Descriptor instead.
 func (*OAuth2Configuration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *OAuth2Configuration) GetCredentials() isOAuth2Configuration_Credentials {
@@ -217,7 +217,7 @@ type OAuth2ClientCredentials struct {
 
 func (x *OAuth2ClientCredentials) Reset() {
 	*x = OAuth2ClientCredentials{}
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -229,7 +229,7 @@ func (x *OAuth2ClientCredentials) String() string {
 func (*OAuth2ClientCredentials) ProtoMessage() {}
 
 func (x *OAuth2ClientCredentials) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -242,7 +242,7 @@ func (x *OAuth2ClientCredentials) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OAuth2ClientCredentials.ProtoReflect.Descriptor instead.
 func (*OAuth2ClientCredentials) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *OAuth2ClientCredentials) GetClientId() string {
@@ -283,7 +283,7 @@ type Configuration_HeaderValues struct {
 
 func (x *Configuration_HeaderValues) Reset() {
 	*x = Configuration_HeaderValues{}
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -295,7 +295,7 @@ func (x *Configuration_HeaderValues) String() string {
 func (*Configuration_HeaderValues) ProtoMessage() {}
 
 func (x *Configuration_HeaderValues) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_client_client_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -308,7 +308,7 @@ func (x *Configuration_HeaderValues) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Configuration_HeaderValues.ProtoReflect.Descriptor instead.
 func (*Configuration_HeaderValues) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{0, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescGZIP(), []int{0, 0}
 }
 
 func (x *Configuration_HeaderValues) GetHeader() string {
@@ -325,11 +325,11 @@ func (x *Configuration_HeaderValues) GetValues() []string {
 	return nil
 }
 
-var File_pkg_proto_configuration_http_client_client_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_http_client_client_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDesc = "" +
 	"\n" +
-	"0pkg/proto/configuration/http/client/client.proto\x12#buildbarn.configuration.http.client\x1a\x1bgoogle/protobuf/empty.proto\x1a%pkg/proto/configuration/tls/tls.proto\"\x89\x03\n" +
+	"Pgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\x12#buildbarn.configuration.http.client\x1aEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto\x1a\x1bgoogle/protobuf/empty.proto\"\x89\x03\n" +
 	"\rConfiguration\x12B\n" +
 	"\x03tls\x18\x01 \x01(\v20.buildbarn.configuration.tls.ClientConfigurationR\x03tls\x12\x1b\n" +
 	"\tproxy_url\x18\x02 \x01(\tR\bproxyUrl\x12`\n" +
@@ -354,19 +354,19 @@ const file_pkg_proto_configuration_http_client_client_proto_rawDesc = "" +
 	"httpClientBEZCgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/clientb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_http_client_client_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_http_client_client_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_http_client_client_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_http_client_client_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_http_client_client_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_http_client_client_proto_rawDesc), len(file_pkg_proto_configuration_http_client_client_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_http_client_client_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_http_client_client_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
-var file_pkg_proto_configuration_http_client_client_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_goTypes = []any{
 	(*Configuration)(nil),              // 0: buildbarn.configuration.http.client.Configuration
 	(*OAuth2Configuration)(nil),        // 1: buildbarn.configuration.http.client.OAuth2Configuration
 	(*OAuth2ClientCredentials)(nil),    // 2: buildbarn.configuration.http.client.OAuth2ClientCredentials
@@ -374,7 +374,7 @@ var file_pkg_proto_configuration_http_client_client_proto_goTypes = []any{
 	(*tls.ClientConfiguration)(nil),    // 4: buildbarn.configuration.tls.ClientConfiguration
 	(*emptypb.Empty)(nil),              // 5: google.protobuf.Empty
 }
-var file_pkg_proto_configuration_http_client_client_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_depIdxs = []int32{
 	4, // 0: buildbarn.configuration.http.client.Configuration.tls:type_name -> buildbarn.configuration.tls.ClientConfiguration
 	3, // 1: buildbarn.configuration.http.client.Configuration.add_headers:type_name -> buildbarn.configuration.http.client.Configuration.HeaderValues
 	1, // 2: buildbarn.configuration.http.client.Configuration.oauth2:type_name -> buildbarn.configuration.http.client.OAuth2Configuration
@@ -388,12 +388,14 @@ var file_pkg_proto_configuration_http_client_client_proto_depIdxs = []int32{
 	0, // [0:6] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_http_client_client_proto_init() }
-func file_pkg_proto_configuration_http_client_client_proto_init() {
-	if File_pkg_proto_configuration_http_client_client_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_http_client_client_proto_msgTypes[1].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[1].OneofWrappers = []any{
 		(*OAuth2Configuration_GoogleDefaultCredentials)(nil),
 		(*OAuth2Configuration_ServiceAccountKey)(nil),
 		(*OAuth2Configuration_ClientCredentials)(nil),
@@ -402,17 +404,17 @@ func file_pkg_proto_configuration_http_client_client_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_http_client_client_proto_rawDesc), len(file_pkg_proto_configuration_http_client_client_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   4,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_http_client_client_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_http_client_client_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_http_client_client_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_http_client_client_proto = out.File
-	file_pkg_proto_configuration_http_client_client_proto_goTypes = nil
-	file_pkg_proto_configuration_http_client_client_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/http/client/client.proto
+++ b/pkg/proto/configuration/http/client/client.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package buildbarn.configuration.http.client;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto";
 import "google/protobuf/empty.proto";
-import "pkg/proto/configuration/tls/tls.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client";
 

--- a/pkg/proto/configuration/http/server/BUILD.bazel
+++ b/pkg/proto/configuration/http/server/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "server_proto",
     srcs = ["server.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/auth:auth_proto",

--- a/pkg/proto/configuration/http/server/server.pb.go
+++ b/pkg/proto/configuration/http/server/server.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/http/server/server.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/http/server/server.proto
 
 package server
 
@@ -39,7 +39,7 @@ type Configuration struct {
 
 func (x *Configuration) Reset() {
 	*x = Configuration{}
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -51,7 +51,7 @@ func (x *Configuration) String() string {
 func (*Configuration) ProtoMessage() {}
 
 func (x *Configuration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64,7 +64,7 @@ func (x *Configuration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Configuration.ProtoReflect.Descriptor instead.
 func (*Configuration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *Configuration) GetListenAddresses() []string {
@@ -106,7 +106,7 @@ type AuthenticationPolicy struct {
 
 func (x *AuthenticationPolicy) Reset() {
 	*x = AuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -118,7 +118,7 @@ func (x *AuthenticationPolicy) String() string {
 func (*AuthenticationPolicy) ProtoMessage() {}
 
 func (x *AuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -131,7 +131,7 @@ func (x *AuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*AuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *AuthenticationPolicy) GetPolicy() isAuthenticationPolicy_Policy {
@@ -259,7 +259,7 @@ type AnyAuthenticationPolicy struct {
 
 func (x *AnyAuthenticationPolicy) Reset() {
 	*x = AnyAuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -271,7 +271,7 @@ func (x *AnyAuthenticationPolicy) String() string {
 func (*AnyAuthenticationPolicy) ProtoMessage() {}
 
 func (x *AnyAuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -284,7 +284,7 @@ func (x *AnyAuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AnyAuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*AnyAuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *AnyAuthenticationPolicy) GetPolicies() []*AuthenticationPolicy {
@@ -316,7 +316,7 @@ type OIDCAuthenticationPolicy struct {
 
 func (x *OIDCAuthenticationPolicy) Reset() {
 	*x = OIDCAuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -328,7 +328,7 @@ func (x *OIDCAuthenticationPolicy) String() string {
 func (*OIDCAuthenticationPolicy) ProtoMessage() {}
 
 func (x *OIDCAuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -341,7 +341,7 @@ func (x *OIDCAuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use OIDCAuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*OIDCAuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{3}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *OIDCAuthenticationPolicy) GetClientId() string {
@@ -458,7 +458,7 @@ type AcceptHeaderAuthenticationPolicy struct {
 
 func (x *AcceptHeaderAuthenticationPolicy) Reset() {
 	*x = AcceptHeaderAuthenticationPolicy{}
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -470,7 +470,7 @@ func (x *AcceptHeaderAuthenticationPolicy) String() string {
 func (*AcceptHeaderAuthenticationPolicy) ProtoMessage() {}
 
 func (x *AcceptHeaderAuthenticationPolicy) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_http_server_server_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -483,7 +483,7 @@ func (x *AcceptHeaderAuthenticationPolicy) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use AcceptHeaderAuthenticationPolicy.ProtoReflect.Descriptor instead.
 func (*AcceptHeaderAuthenticationPolicy) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{4}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *AcceptHeaderAuthenticationPolicy) GetMediaTypes() []string {
@@ -500,11 +500,11 @@ func (x *AcceptHeaderAuthenticationPolicy) GetPolicy() *AuthenticationPolicy {
 	return nil
 }
 
-var File_pkg_proto_configuration_http_server_server_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_http_server_server_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDesc = "" +
 	"\n" +
-	"0pkg/proto/configuration/http/server/server.proto\x12#buildbarn.configuration.http.server\x1a\x1bgoogle/protobuf/empty.proto\x1a\x19pkg/proto/auth/auth.proto\x1a'pkg/proto/configuration/grpc/grpc.proto\x1a0pkg/proto/configuration/http/client/client.proto\x1a%pkg/proto/configuration/jwt/jwt.proto\x1a%pkg/proto/configuration/tls/tls.proto\x1a/pkg/proto/configuration/jmespath/jmespath.proto\"\xee\x01\n" +
+	"Pgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/server/server.proto\x12#buildbarn.configuration.http.server\x1a9github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto\x1aGgithub.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto\x1aEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/jwt/jwt.proto\x1aEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xee\x01\n" +
 	"\rConfiguration\x12)\n" +
 	"\x10listen_addresses\x18\x01 \x03(\tR\x0flistenAddresses\x12n\n" +
 	"\x15authentication_policy\x18\x02 \x01(\v29.buildbarn.configuration.http.server.AuthenticationPolicyR\x14authenticationPolicy\x12B\n" +
@@ -542,19 +542,19 @@ const file_pkg_proto_configuration_http_server_server_proto_rawDesc = "" +
 	"\x06policy\x18\x02 \x01(\v29.buildbarn.configuration.http.server.AuthenticationPolicyR\x06policyBEZCgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/serverb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_http_server_server_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_http_server_server_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_http_server_server_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_http_server_server_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_http_server_server_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_http_server_server_proto_rawDesc), len(file_pkg_proto_configuration_http_server_server_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_http_server_server_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_http_server_server_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
-var file_pkg_proto_configuration_http_server_server_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_goTypes = []any{
 	(*Configuration)(nil),                              // 0: buildbarn.configuration.http.server.Configuration
 	(*AuthenticationPolicy)(nil),                       // 1: buildbarn.configuration.http.server.AuthenticationPolicy
 	(*AnyAuthenticationPolicy)(nil),                    // 2: buildbarn.configuration.http.server.AnyAuthenticationPolicy
@@ -568,7 +568,7 @@ var file_pkg_proto_configuration_http_server_server_proto_goTypes = []any{
 	(*jmespath.Expression)(nil),                        // 10: buildbarn.configuration.jmespath.Expression
 	(*client.Configuration)(nil),                       // 11: buildbarn.configuration.http.client.Configuration
 }
-var file_pkg_proto_configuration_http_server_server_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_depIdxs = []int32{
 	1,  // 0: buildbarn.configuration.http.server.Configuration.authentication_policy:type_name -> buildbarn.configuration.http.server.AuthenticationPolicy
 	5,  // 1: buildbarn.configuration.http.server.Configuration.tls:type_name -> buildbarn.configuration.tls.ServerConfiguration
 	6,  // 2: buildbarn.configuration.http.server.AuthenticationPolicy.allow:type_name -> buildbarn.auth.AuthenticationMetadata
@@ -589,12 +589,14 @@ var file_pkg_proto_configuration_http_server_server_proto_depIdxs = []int32{
 	0,  // [0:13] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_http_server_server_proto_init() }
-func file_pkg_proto_configuration_http_server_server_proto_init() {
-	if File_pkg_proto_configuration_http_server_server_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_http_server_server_proto_msgTypes[1].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[1].OneofWrappers = []any{
 		(*AuthenticationPolicy_Allow)(nil),
 		(*AuthenticationPolicy_Any)(nil),
 		(*AuthenticationPolicy_Deny)(nil),
@@ -603,7 +605,7 @@ func file_pkg_proto_configuration_http_server_server_proto_init() {
 		(*AuthenticationPolicy_AcceptHeader)(nil),
 		(*AuthenticationPolicy_Remote)(nil),
 	}
-	file_pkg_proto_configuration_http_server_server_proto_msgTypes[3].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes[3].OneofWrappers = []any{
 		(*OIDCAuthenticationPolicy_UserInfoEndpointUrl)(nil),
 		(*OIDCAuthenticationPolicy_UseIdTokenClaims)(nil),
 	}
@@ -611,17 +613,17 @@ func file_pkg_proto_configuration_http_server_server_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_http_server_server_proto_rawDesc), len(file_pkg_proto_configuration_http_server_server_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_http_server_server_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_http_server_server_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_http_server_server_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_http_server_server_proto = out.File
-	file_pkg_proto_configuration_http_server_server_proto_goTypes = nil
-	file_pkg_proto_configuration_http_server_server_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_server_server_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/http/server/server.proto
+++ b/pkg/proto/configuration/http/server/server.proto
@@ -2,13 +2,13 @@ syntax = "proto3";
 
 package buildbarn.configuration.http.server;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/grpc/grpc.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/jwt/jwt.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto";
 import "google/protobuf/empty.proto";
-import "pkg/proto/auth/auth.proto";
-import "pkg/proto/configuration/grpc/grpc.proto";
-import "pkg/proto/configuration/http/client/client.proto";
-import "pkg/proto/configuration/jwt/jwt.proto";
-import "pkg/proto/configuration/tls/tls.proto";
-import "pkg/proto/configuration/jmespath/jmespath.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/server";
 

--- a/pkg/proto/configuration/jmespath/BUILD.bazel
+++ b/pkg/proto/configuration/jmespath/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "jmespath_proto",
     srcs = ["jmespath.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = ["@protobuf//:struct_proto"],
 )

--- a/pkg/proto/configuration/jmespath/jmespath.pb.go
+++ b/pkg/proto/configuration/jmespath/jmespath.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/jmespath/jmespath.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto
 
 package jmespath
 
@@ -33,7 +33,7 @@ type Expression struct {
 
 func (x *Expression) Reset() {
 	*x = Expression{}
-	mi := &file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -45,7 +45,7 @@ func (x *Expression) String() string {
 func (*Expression) ProtoMessage() {}
 
 func (x *Expression) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58,7 +58,7 @@ func (x *Expression) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Expression.ProtoReflect.Descriptor instead.
 func (*Expression) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *Expression) GetExpression() string {
@@ -92,7 +92,7 @@ type File struct {
 
 func (x *File) Reset() {
 	*x = File{}
-	mi := &file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -104,7 +104,7 @@ func (x *File) String() string {
 func (*File) ProtoMessage() {}
 
 func (x *File) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -117,7 +117,7 @@ func (x *File) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use File.ProtoReflect.Descriptor instead.
 func (*File) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *File) GetKey() string {
@@ -144,7 +144,7 @@ type TestVector struct {
 
 func (x *TestVector) Reset() {
 	*x = TestVector{}
-	mi := &file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -156,7 +156,7 @@ func (x *TestVector) String() string {
 func (*TestVector) ProtoMessage() {}
 
 func (x *TestVector) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -169,7 +169,7 @@ func (x *TestVector) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TestVector.ProtoReflect.Descriptor instead.
 func (*TestVector) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *TestVector) GetInput() *structpb.Struct {
@@ -186,11 +186,11 @@ func (x *TestVector) GetExpectedOutput() *structpb.Value {
 	return nil
 }
 
-var File_pkg_proto_configuration_jmespath_jmespath_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc = "" +
 	"\n" +
-	"/pkg/proto/configuration/jmespath/jmespath.proto\x12 buildbarn.configuration.jmespath\x1a\x1cgoogle/protobuf/struct.proto\"\xbb\x01\n" +
+	"Ogithub.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto\x12 buildbarn.configuration.jmespath\x1a\x1cgoogle/protobuf/struct.proto\"\xbb\x01\n" +
 	"\n" +
 	"Expression\x12\x1e\n" +
 	"\n" +
@@ -207,26 +207,26 @@ const file_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc = "" +
 	"\x0fexpected_output\x18\x02 \x01(\v2\x16.google.protobuf.ValueR\x0eexpectedOutputBBZ@github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespathb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc), len(file_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_jmespath_jmespath_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_pkg_proto_configuration_jmespath_jmespath_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_goTypes = []any{
 	(*Expression)(nil),      // 0: buildbarn.configuration.jmespath.Expression
 	(*File)(nil),            // 1: buildbarn.configuration.jmespath.File
 	(*TestVector)(nil),      // 2: buildbarn.configuration.jmespath.TestVector
 	(*structpb.Struct)(nil), // 3: google.protobuf.Struct
 	(*structpb.Value)(nil),  // 4: google.protobuf.Value
 }
-var file_pkg_proto_configuration_jmespath_jmespath_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.jmespath.Expression.files:type_name -> buildbarn.configuration.jmespath.File
 	2, // 1: buildbarn.configuration.jmespath.Expression.test_vectors:type_name -> buildbarn.configuration.jmespath.TestVector
 	3, // 2: buildbarn.configuration.jmespath.TestVector.input:type_name -> google.protobuf.Struct
@@ -238,26 +238,28 @@ var file_pkg_proto_configuration_jmespath_jmespath_proto_depIdxs = []int32{
 	0, // [0:4] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_jmespath_jmespath_proto_init() }
-func file_pkg_proto_configuration_jmespath_jmespath_proto_init() {
-	if File_pkg_proto_configuration_jmespath_jmespath_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc), len(file_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_jmespath_jmespath_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_jmespath_jmespath_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_jmespath_jmespath_proto = out.File
-	file_pkg_proto_configuration_jmespath_jmespath_proto_goTypes = nil
-	file_pkg_proto_configuration_jmespath_jmespath_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jmespath_jmespath_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/jwt/BUILD.bazel
+++ b/pkg/proto/configuration/jwt/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "jwt_proto",
     srcs = ["jwt.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/configuration/eviction:eviction_proto",

--- a/pkg/proto/configuration/jwt/jwt.pb.go
+++ b/pkg/proto/configuration/jwt/jwt.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/jwt/jwt.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/jwt/jwt.proto
 
 package jwt
 
@@ -41,7 +41,7 @@ type AuthorizationHeaderParserConfiguration struct {
 
 func (x *AuthorizationHeaderParserConfiguration) Reset() {
 	*x = AuthorizationHeaderParserConfiguration{}
-	mi := &file_pkg_proto_configuration_jwt_jwt_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -53,7 +53,7 @@ func (x *AuthorizationHeaderParserConfiguration) String() string {
 func (*AuthorizationHeaderParserConfiguration) ProtoMessage() {}
 
 func (x *AuthorizationHeaderParserConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_jwt_jwt_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66,7 +66,7 @@ func (x *AuthorizationHeaderParserConfiguration) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use AuthorizationHeaderParserConfiguration.ProtoReflect.Descriptor instead.
 func (*AuthorizationHeaderParserConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_jwt_jwt_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *AuthorizationHeaderParserConfiguration) GetJwks() isAuthorizationHeaderParserConfiguration_Jwks {
@@ -140,11 +140,11 @@ func (*AuthorizationHeaderParserConfiguration_JwksInline) isAuthorizationHeaderP
 func (*AuthorizationHeaderParserConfiguration_JwksFile) isAuthorizationHeaderParserConfiguration_Jwks() {
 }
 
-var File_pkg_proto_configuration_jwt_jwt_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_jwt_jwt_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDesc = "" +
 	"\n" +
-	"%pkg/proto/configuration/jwt/jwt.proto\x12\x1bbuildbarn.configuration.jwt\x1a\x1cgoogle/protobuf/struct.proto\x1a/pkg/proto/configuration/eviction/eviction.proto\x1a/pkg/proto/configuration/jmespath/jmespath.proto\"\xc0\x04\n" +
+	"Egithub.com/buildbarn/bb-storage/pkg/proto/configuration/jwt/jwt.proto\x12\x1bbuildbarn.configuration.jwt\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto\x1a\x1cgoogle/protobuf/struct.proto\"\xc0\x04\n" +
 	"&AuthorizationHeaderParserConfiguration\x12:\n" +
 	"\vjwks_inline\x18\a \x01(\v2\x17.google.protobuf.StructH\x00R\n" +
 	"jwksInline\x12\x1d\n" +
@@ -156,25 +156,25 @@ const file_pkg_proto_configuration_jwt_jwt_proto_rawDesc = "" +
 	"\x04jwksJ\x04\b\x01\x10\x02J\x04\b\x02\x10\x03B=Z;github.com/buildbarn/bb-storage/pkg/proto/configuration/jwtb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_jwt_jwt_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_jwt_jwt_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_jwt_jwt_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_jwt_jwt_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_jwt_jwt_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_jwt_jwt_proto_rawDesc), len(file_pkg_proto_configuration_jwt_jwt_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_jwt_jwt_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_jwt_jwt_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_jwt_jwt_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_goTypes = []any{
 	(*AuthorizationHeaderParserConfiguration)(nil), // 0: buildbarn.configuration.jwt.AuthorizationHeaderParserConfiguration
 	(*structpb.Struct)(nil),                        // 1: google.protobuf.Struct
 	(eviction.CacheReplacementPolicy)(0),           // 2: buildbarn.configuration.eviction.CacheReplacementPolicy
 	(*jmespath.Expression)(nil),                    // 3: buildbarn.configuration.jmespath.Expression
 }
-var file_pkg_proto_configuration_jwt_jwt_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.jwt.AuthorizationHeaderParserConfiguration.jwks_inline:type_name -> google.protobuf.Struct
 	2, // 1: buildbarn.configuration.jwt.AuthorizationHeaderParserConfiguration.cache_replacement_policy:type_name -> buildbarn.configuration.eviction.CacheReplacementPolicy
 	3, // 2: buildbarn.configuration.jwt.AuthorizationHeaderParserConfiguration.claims_validation_jmespath_expression:type_name -> buildbarn.configuration.jmespath.Expression
@@ -186,12 +186,12 @@ var file_pkg_proto_configuration_jwt_jwt_proto_depIdxs = []int32{
 	0, // [0:4] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_jwt_jwt_proto_init() }
-func file_pkg_proto_configuration_jwt_jwt_proto_init() {
-	if File_pkg_proto_configuration_jwt_jwt_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_jwt_jwt_proto_msgTypes[0].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_msgTypes[0].OneofWrappers = []any{
 		(*AuthorizationHeaderParserConfiguration_JwksInline)(nil),
 		(*AuthorizationHeaderParserConfiguration_JwksFile)(nil),
 	}
@@ -199,17 +199,17 @@ func file_pkg_proto_configuration_jwt_jwt_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_jwt_jwt_proto_rawDesc), len(file_pkg_proto_configuration_jwt_jwt_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_jwt_jwt_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_jwt_jwt_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_jwt_jwt_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_jwt_jwt_proto = out.File
-	file_pkg_proto_configuration_jwt_jwt_proto_goTypes = nil
-	file_pkg_proto_configuration_jwt_jwt_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_jwt_jwt_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/jwt/jwt.proto
+++ b/pkg/proto/configuration/jwt/jwt.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package buildbarn.configuration.jwt;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/eviction/eviction.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto";
 import "google/protobuf/struct.proto";
-import "pkg/proto/configuration/eviction/eviction.proto";
-import "pkg/proto/configuration/jmespath/jmespath.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/jwt";
 

--- a/pkg/proto/configuration/sync_jwks_to_configmap/BUILD.bazel
+++ b/pkg/proto/configuration/sync_jwks_to_configmap/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "sync_jwks_to_configmap_proto",
     srcs = ["sync_jwks_to_configmap.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = ["//pkg/proto/configuration/http/client:client_proto"],
 )

--- a/pkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.pb.go
+++ b/pkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.proto
 
 package sync_jwks_to_configmap
 
@@ -35,7 +35,7 @@ type ApplicationConfiguration struct {
 
 func (x *ApplicationConfiguration) Reset() {
 	*x = ApplicationConfiguration{}
-	mi := &file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -47,7 +47,7 @@ func (x *ApplicationConfiguration) String() string {
 func (*ApplicationConfiguration) ProtoMessage() {}
 
 func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -60,7 +60,7 @@ func (x *ApplicationConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ApplicationConfiguration.ProtoReflect.Descriptor instead.
 func (*ApplicationConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ApplicationConfiguration) GetHttpClient() *client.Configuration {
@@ -98,11 +98,11 @@ func (x *ApplicationConfiguration) GetConfigMapKey() string {
 	return ""
 }
 
-var File_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc = "" +
 	"\n" +
-	"Kpkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.proto\x12.buildbarn.configuration.sync_jwks_to_configmap\x1a0pkg/proto/configuration/http/client/client.proto\"\x8a\x02\n" +
+	"kgithub.com/buildbarn/bb-storage/pkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.proto\x12.buildbarn.configuration.sync_jwks_to_configmap\x1aPgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\"\x8a\x02\n" +
 	"\x18ApplicationConfiguration\x12S\n" +
 	"\vhttp_client\x18\x01 \x01(\v22.buildbarn.configuration.http.client.ConfigurationR\n" +
 	"httpClient\x12\x19\n" +
@@ -112,23 +112,23 @@ const file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap
 	"\x0econfig_map_key\x18\x05 \x01(\tR\fconfigMapKeyBPZNgithub.com/buildbarn/bb-storage/pkg/proto/configuration/sync_jwks_to_configmapb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc), len(file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_goTypes = []any{
 	(*ApplicationConfiguration)(nil), // 0: buildbarn.configuration.sync_jwks_to_configmap.ApplicationConfiguration
 	(*client.Configuration)(nil),     // 1: buildbarn.configuration.http.client.Configuration
 }
-var file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.sync_jwks_to_configmap.ApplicationConfiguration.http_client:type_name -> buildbarn.configuration.http.client.Configuration
 	1, // [1:1] is the sub-list for method output_type
 	1, // [1:1] is the sub-list for method input_type
@@ -137,26 +137,28 @@ var file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_p
 	0, // [0:1] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_init() }
-func file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_init() {
-	if File_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto != nil {
+func init() {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_init()
+}
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc), len(file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto = out.File
-	file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_goTypes = nil
-	file_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_sync_jwks_to_configmap_sync_jwks_to_configmap_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.proto
+++ b/pkg/proto/configuration/sync_jwks_to_configmap/sync_jwks_to_configmap.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package buildbarn.configuration.sync_jwks_to_configmap;
 
-import "pkg/proto/configuration/http/client/client.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/sync_jwks_to_configmap";
 

--- a/pkg/proto/configuration/tls/BUILD.bazel
+++ b/pkg/proto/configuration/tls/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "tls_proto",
     srcs = ["tls.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = ["@protobuf//:duration_proto"],
 )

--- a/pkg/proto/configuration/tls/tls.pb.go
+++ b/pkg/proto/configuration/tls/tls.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/tls/tls.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto
 
 package tls
 
@@ -34,7 +34,7 @@ type ClientConfiguration struct {
 
 func (x *ClientConfiguration) Reset() {
 	*x = ClientConfiguration{}
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -46,7 +46,7 @@ func (x *ClientConfiguration) String() string {
 func (*ClientConfiguration) ProtoMessage() {}
 
 func (x *ClientConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59,7 +59,7 @@ func (x *ClientConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ClientConfiguration.ProtoReflect.Descriptor instead.
 func (*ClientConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ClientConfiguration) GetServerCertificateAuthorities() string {
@@ -100,7 +100,7 @@ type ServerConfiguration struct {
 
 func (x *ServerConfiguration) Reset() {
 	*x = ServerConfiguration{}
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -112,7 +112,7 @@ func (x *ServerConfiguration) String() string {
 func (*ServerConfiguration) ProtoMessage() {}
 
 func (x *ServerConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -125,7 +125,7 @@ func (x *ServerConfiguration) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ServerConfiguration.ProtoReflect.Descriptor instead.
 func (*ServerConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *ServerConfiguration) GetCipherSuites() []string {
@@ -155,7 +155,7 @@ type X509KeyPair struct {
 
 func (x *X509KeyPair) Reset() {
 	*x = X509KeyPair{}
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -167,7 +167,7 @@ func (x *X509KeyPair) String() string {
 func (*X509KeyPair) ProtoMessage() {}
 
 func (x *X509KeyPair) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -180,7 +180,7 @@ func (x *X509KeyPair) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use X509KeyPair.ProtoReflect.Descriptor instead.
 func (*X509KeyPair) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *X509KeyPair) GetKeyPair() isX509KeyPair_KeyPair {
@@ -234,7 +234,7 @@ type X509KeyPair_Inline struct {
 
 func (x *X509KeyPair_Inline) Reset() {
 	*x = X509KeyPair_Inline{}
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -246,7 +246,7 @@ func (x *X509KeyPair_Inline) String() string {
 func (*X509KeyPair_Inline) ProtoMessage() {}
 
 func (x *X509KeyPair_Inline) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -259,7 +259,7 @@ func (x *X509KeyPair_Inline) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use X509KeyPair_Inline.ProtoReflect.Descriptor instead.
 func (*X509KeyPair_Inline) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{2, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{2, 0}
 }
 
 func (x *X509KeyPair_Inline) GetCertificate() string {
@@ -287,7 +287,7 @@ type X509KeyPair_Files struct {
 
 func (x *X509KeyPair_Files) Reset() {
 	*x = X509KeyPair_Files{}
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -299,7 +299,7 @@ func (x *X509KeyPair_Files) String() string {
 func (*X509KeyPair_Files) ProtoMessage() {}
 
 func (x *X509KeyPair_Files) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_tls_tls_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -312,7 +312,7 @@ func (x *X509KeyPair_Files) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use X509KeyPair_Files.ProtoReflect.Descriptor instead.
 func (*X509KeyPair_Files) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{2, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescGZIP(), []int{2, 1}
 }
 
 func (x *X509KeyPair_Files) GetCertificatePath() string {
@@ -336,11 +336,11 @@ func (x *X509KeyPair_Files) GetRefreshInterval() *durationpb.Duration {
 	return nil
 }
 
-var File_pkg_proto_configuration_tls_tls_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_tls_tls_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDesc = "" +
 	"\n" +
-	"%pkg/proto/configuration/tls/tls.proto\x12\x1bbuildbarn.configuration.tls\x1a\x1egoogle/protobuf/duration.proto\"\xff\x01\n" +
+	"Egithub.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto\x12\x1bbuildbarn.configuration.tls\x1a\x1egoogle/protobuf/duration.proto\"\xff\x01\n" +
 	"\x13ClientConfiguration\x12D\n" +
 	"\x1eserver_certificate_authorities\x18\x01 \x01(\tR\x1cserverCertificateAuthorities\x12#\n" +
 	"\rcipher_suites\x18\x04 \x03(\tR\fcipherSuites\x12\x1f\n" +
@@ -365,19 +365,19 @@ const file_pkg_proto_configuration_tls_tls_proto_rawDesc = "" +
 	"\bkey_pairB=Z;github.com/buildbarn/bb-storage/pkg/proto/configuration/tlsb\x06proto3"
 
 var (
-	file_pkg_proto_configuration_tls_tls_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_tls_tls_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_tls_tls_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_tls_tls_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_tls_tls_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_tls_tls_proto_rawDesc), len(file_pkg_proto_configuration_tls_tls_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_tls_tls_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_tls_tls_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
-var file_pkg_proto_configuration_tls_tls_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes = make([]protoimpl.MessageInfo, 5)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_goTypes = []any{
 	(*ClientConfiguration)(nil), // 0: buildbarn.configuration.tls.ClientConfiguration
 	(*ServerConfiguration)(nil), // 1: buildbarn.configuration.tls.ServerConfiguration
 	(*X509KeyPair)(nil),         // 2: buildbarn.configuration.tls.X509KeyPair
@@ -385,7 +385,7 @@ var file_pkg_proto_configuration_tls_tls_proto_goTypes = []any{
 	(*X509KeyPair_Files)(nil),   // 4: buildbarn.configuration.tls.X509KeyPair.Files
 	(*durationpb.Duration)(nil), // 5: google.protobuf.Duration
 }
-var file_pkg_proto_configuration_tls_tls_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_depIdxs = []int32{
 	2, // 0: buildbarn.configuration.tls.ClientConfiguration.client_key_pair:type_name -> buildbarn.configuration.tls.X509KeyPair
 	2, // 1: buildbarn.configuration.tls.ServerConfiguration.server_key_pair:type_name -> buildbarn.configuration.tls.X509KeyPair
 	3, // 2: buildbarn.configuration.tls.X509KeyPair.inline:type_name -> buildbarn.configuration.tls.X509KeyPair.Inline
@@ -398,12 +398,12 @@ var file_pkg_proto_configuration_tls_tls_proto_depIdxs = []int32{
 	0, // [0:5] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_tls_tls_proto_init() }
-func file_pkg_proto_configuration_tls_tls_proto_init() {
-	if File_pkg_proto_configuration_tls_tls_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto != nil {
 		return
 	}
-	file_pkg_proto_configuration_tls_tls_proto_msgTypes[2].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes[2].OneofWrappers = []any{
 		(*X509KeyPair_Inline_)(nil),
 		(*X509KeyPair_Files_)(nil),
 	}
@@ -411,17 +411,17 @@ func file_pkg_proto_configuration_tls_tls_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_tls_tls_proto_rawDesc), len(file_pkg_proto_configuration_tls_tls_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   5,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_tls_tls_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_tls_tls_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_tls_tls_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_tls_tls_proto = out.File
-	file_pkg_proto_configuration_tls_tls_proto_goTypes = nil
-	file_pkg_proto_configuration_tls_tls_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_tls_tls_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/x509/BUILD.bazel
+++ b/pkg/proto/configuration/x509/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "x509_proto",
     srcs = ["x509.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = ["//pkg/proto/configuration/jmespath:jmespath_proto"],
 )

--- a/pkg/proto/configuration/x509/x509.pb.go
+++ b/pkg/proto/configuration/x509/x509.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/configuration/x509/x509.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/configuration/x509/x509.proto
 
 package x509
 
@@ -33,7 +33,7 @@ type ClientCertificateVerifierConfiguration struct {
 
 func (x *ClientCertificateVerifierConfiguration) Reset() {
 	*x = ClientCertificateVerifierConfiguration{}
-	mi := &file_pkg_proto_configuration_x509_x509_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -45,7 +45,7 @@ func (x *ClientCertificateVerifierConfiguration) String() string {
 func (*ClientCertificateVerifierConfiguration) ProtoMessage() {}
 
 func (x *ClientCertificateVerifierConfiguration) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_configuration_x509_x509_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58,7 +58,7 @@ func (x *ClientCertificateVerifierConfiguration) ProtoReflect() protoreflect.Mes
 
 // Deprecated: Use ClientCertificateVerifierConfiguration.ProtoReflect.Descriptor instead.
 func (*ClientCertificateVerifierConfiguration) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_configuration_x509_x509_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ClientCertificateVerifierConfiguration) GetClientCertificateAuthorities() string {
@@ -82,34 +82,34 @@ func (x *ClientCertificateVerifierConfiguration) GetMetadataExtractionJmespathEx
 	return nil
 }
 
-var File_pkg_proto_configuration_x509_x509_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_configuration_x509_x509_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDesc = "" +
 	"\n" +
-	"'pkg/proto/configuration/x509/x509.proto\x12\x1cbuildbarn.configuration.x509\x1a/pkg/proto/configuration/jmespath/jmespath.proto\"\xe8\x02\n" +
+	"Ggithub.com/buildbarn/bb-storage/pkg/proto/configuration/x509/x509.proto\x12\x1cbuildbarn.configuration.x509\x1aOgithub.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto\"\xe8\x02\n" +
 	"&ClientCertificateVerifierConfiguration\x12D\n" +
 	"\x1eclient_certificate_authorities\x18\x01 \x01(\tR\x1cclientCertificateAuthorities\x12r\n" +
 	"\x1evalidation_jmespath_expression\x18\x02 \x01(\v2,.buildbarn.configuration.jmespath.ExpressionR\x1cvalidationJmespathExpression\x12\x83\x01\n" +
 	"'metadata_extraction_jmespath_expression\x18\x03 \x01(\v2,.buildbarn.configuration.jmespath.ExpressionR$metadataExtractionJmespathExpressionB>Z<github.com/buildbarn/bb-storage/pkg/proto/configuration/x509b\x06proto3"
 
 var (
-	file_pkg_proto_configuration_x509_x509_proto_rawDescOnce sync.Once
-	file_pkg_proto_configuration_x509_x509_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDescData []byte
 )
 
-func file_pkg_proto_configuration_x509_x509_proto_rawDescGZIP() []byte {
-	file_pkg_proto_configuration_x509_x509_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_configuration_x509_x509_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_x509_x509_proto_rawDesc), len(file_pkg_proto_configuration_x509_x509_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDesc)))
 	})
-	return file_pkg_proto_configuration_x509_x509_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDescData
 }
 
-var file_pkg_proto_configuration_x509_x509_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_configuration_x509_x509_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_goTypes = []any{
 	(*ClientCertificateVerifierConfiguration)(nil), // 0: buildbarn.configuration.x509.ClientCertificateVerifierConfiguration
 	(*jmespath.Expression)(nil),                    // 1: buildbarn.configuration.jmespath.Expression
 }
-var file_pkg_proto_configuration_x509_x509_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_depIdxs = []int32{
 	1, // 0: buildbarn.configuration.x509.ClientCertificateVerifierConfiguration.validation_jmespath_expression:type_name -> buildbarn.configuration.jmespath.Expression
 	1, // 1: buildbarn.configuration.x509.ClientCertificateVerifierConfiguration.metadata_extraction_jmespath_expression:type_name -> buildbarn.configuration.jmespath.Expression
 	2, // [2:2] is the sub-list for method output_type
@@ -119,26 +119,26 @@ var file_pkg_proto_configuration_x509_x509_proto_depIdxs = []int32{
 	0, // [0:2] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_configuration_x509_x509_proto_init() }
-func file_pkg_proto_configuration_x509_x509_proto_init() {
-	if File_pkg_proto_configuration_x509_x509_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_configuration_x509_x509_proto_rawDesc), len(file_pkg_proto_configuration_x509_x509_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_configuration_x509_x509_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_configuration_x509_x509_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_configuration_x509_x509_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_configuration_x509_x509_proto = out.File
-	file_pkg_proto_configuration_x509_x509_proto_goTypes = nil
-	file_pkg_proto_configuration_x509_x509_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_x509_x509_proto_depIdxs = nil
 }

--- a/pkg/proto/configuration/x509/x509.proto
+++ b/pkg/proto/configuration/x509/x509.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package buildbarn.configuration.x509;
 
-import "pkg/proto/configuration/jmespath/jmespath.proto";
+import "github.com/buildbarn/bb-storage/pkg/proto/configuration/jmespath/jmespath.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/configuration/x509";
 

--- a/pkg/proto/fsac/BUILD.bazel
+++ b/pkg/proto/fsac/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "fsac_proto",
     srcs = ["fsac.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_proto",

--- a/pkg/proto/fsac/fsac.pb.go
+++ b/pkg/proto/fsac/fsac.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/fsac/fsac.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/fsac/fsac.proto
 
 package fsac
 
@@ -33,7 +33,7 @@ type FileSystemAccessProfile struct {
 
 func (x *FileSystemAccessProfile) Reset() {
 	*x = FileSystemAccessProfile{}
-	mi := &file_pkg_proto_fsac_fsac_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -45,7 +45,7 @@ func (x *FileSystemAccessProfile) String() string {
 func (*FileSystemAccessProfile) ProtoMessage() {}
 
 func (x *FileSystemAccessProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_fsac_fsac_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -58,7 +58,7 @@ func (x *FileSystemAccessProfile) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use FileSystemAccessProfile.ProtoReflect.Descriptor instead.
 func (*FileSystemAccessProfile) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_fsac_fsac_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *FileSystemAccessProfile) GetBloomFilter() []byte {
@@ -86,7 +86,7 @@ type GetFileSystemAccessProfileRequest struct {
 
 func (x *GetFileSystemAccessProfileRequest) Reset() {
 	*x = GetFileSystemAccessProfileRequest{}
-	mi := &file_pkg_proto_fsac_fsac_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -98,7 +98,7 @@ func (x *GetFileSystemAccessProfileRequest) String() string {
 func (*GetFileSystemAccessProfileRequest) ProtoMessage() {}
 
 func (x *GetFileSystemAccessProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_fsac_fsac_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -111,7 +111,7 @@ func (x *GetFileSystemAccessProfileRequest) ProtoReflect() protoreflect.Message 
 
 // Deprecated: Use GetFileSystemAccessProfileRequest.ProtoReflect.Descriptor instead.
 func (*GetFileSystemAccessProfileRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_fsac_fsac_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *GetFileSystemAccessProfileRequest) GetInstanceName() string {
@@ -147,7 +147,7 @@ type UpdateFileSystemAccessProfileRequest struct {
 
 func (x *UpdateFileSystemAccessProfileRequest) Reset() {
 	*x = UpdateFileSystemAccessProfileRequest{}
-	mi := &file_pkg_proto_fsac_fsac_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -159,7 +159,7 @@ func (x *UpdateFileSystemAccessProfileRequest) String() string {
 func (*UpdateFileSystemAccessProfileRequest) ProtoMessage() {}
 
 func (x *UpdateFileSystemAccessProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_fsac_fsac_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -172,7 +172,7 @@ func (x *UpdateFileSystemAccessProfileRequest) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use UpdateFileSystemAccessProfileRequest.ProtoReflect.Descriptor instead.
 func (*UpdateFileSystemAccessProfileRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_fsac_fsac_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *UpdateFileSystemAccessProfileRequest) GetInstanceName() string {
@@ -203,11 +203,11 @@ func (x *UpdateFileSystemAccessProfileRequest) GetFileSystemAccessProfile() *Fil
 	return nil
 }
 
-var File_pkg_proto_fsac_fsac_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_fsac_fsac_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDesc = "" +
 	"\n" +
-	"\x19pkg/proto/fsac/fsac.proto\x12\x0ebuildbarn.fsac\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1bgoogle/protobuf/empty.proto\"{\n" +
+	"9github.com/buildbarn/bb-storage/pkg/proto/fsac/fsac.proto\x12\x0ebuildbarn.fsac\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1bgoogle/protobuf/empty.proto\"{\n" +
 	"\x17FileSystemAccessProfile\x12!\n" +
 	"\fbloom_filter\x18\x01 \x01(\fR\vbloomFilter\x12=\n" +
 	"\x1bbloom_filter_hash_functions\x18\x02 \x01(\rR\x18bloomFilterHashFunctions\"\x85\x02\n" +
@@ -225,19 +225,19 @@ const file_pkg_proto_fsac_fsac_proto_rawDesc = "" +
 	"\x1dUpdateFileSystemAccessProfile\x124.buildbarn.fsac.UpdateFileSystemAccessProfileRequest\x1a\x16.google.protobuf.EmptyB0Z.github.com/buildbarn/bb-storage/pkg/proto/fsacb\x06proto3"
 
 var (
-	file_pkg_proto_fsac_fsac_proto_rawDescOnce sync.Once
-	file_pkg_proto_fsac_fsac_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescData []byte
 )
 
-func file_pkg_proto_fsac_fsac_proto_rawDescGZIP() []byte {
-	file_pkg_proto_fsac_fsac_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_fsac_fsac_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_fsac_fsac_proto_rawDesc), len(file_pkg_proto_fsac_fsac_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDesc)))
 	})
-	return file_pkg_proto_fsac_fsac_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDescData
 }
 
-var file_pkg_proto_fsac_fsac_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_pkg_proto_fsac_fsac_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_goTypes = []any{
 	(*FileSystemAccessProfile)(nil),              // 0: buildbarn.fsac.FileSystemAccessProfile
 	(*GetFileSystemAccessProfileRequest)(nil),    // 1: buildbarn.fsac.GetFileSystemAccessProfileRequest
 	(*UpdateFileSystemAccessProfileRequest)(nil), // 2: buildbarn.fsac.UpdateFileSystemAccessProfileRequest
@@ -245,7 +245,7 @@ var file_pkg_proto_fsac_fsac_proto_goTypes = []any{
 	(*v2.Digest)(nil),                            // 4: build.bazel.remote.execution.v2.Digest
 	(*emptypb.Empty)(nil),                        // 5: google.protobuf.Empty
 }
-var file_pkg_proto_fsac_fsac_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_depIdxs = []int32{
 	3, // 0: buildbarn.fsac.GetFileSystemAccessProfileRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
 	4, // 1: buildbarn.fsac.GetFileSystemAccessProfileRequest.reduced_action_digest:type_name -> build.bazel.remote.execution.v2.Digest
 	3, // 2: buildbarn.fsac.UpdateFileSystemAccessProfileRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
@@ -262,26 +262,26 @@ var file_pkg_proto_fsac_fsac_proto_depIdxs = []int32{
 	0, // [0:5] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_fsac_fsac_proto_init() }
-func file_pkg_proto_fsac_fsac_proto_init() {
-	if File_pkg_proto_fsac_fsac_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_fsac_fsac_proto_rawDesc), len(file_pkg_proto_fsac_fsac_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_pkg_proto_fsac_fsac_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_fsac_fsac_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_fsac_fsac_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_fsac_fsac_proto = out.File
-	file_pkg_proto_fsac_fsac_proto_goTypes = nil
-	file_pkg_proto_fsac_fsac_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_fsac_fsac_proto_depIdxs = nil
 }

--- a/pkg/proto/fsac/fsac_grpc.pb.go
+++ b/pkg/proto/fsac/fsac_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.5.1
 // - protoc             v6.31.1
-// source: pkg/proto/fsac/fsac.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/fsac/fsac.proto
 
 package fsac
 
@@ -154,5 +154,5 @@ var FileSystemAccessCache_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "pkg/proto/fsac/fsac.proto",
+	Metadata: "github.com/buildbarn/bb-storage/pkg/proto/fsac/fsac.proto",
 }

--- a/pkg/proto/http/oidc/BUILD.bazel
+++ b/pkg/proto/http/oidc/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "oidc_proto",
     srcs = ["oidc.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/proto/auth:auth_proto",

--- a/pkg/proto/http/oidc/oidc.pb.go
+++ b/pkg/proto/http/oidc/oidc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/http/oidc/oidc.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/http/oidc/oidc.proto
 
 package oidc
 
@@ -37,7 +37,7 @@ type CookieValue struct {
 
 func (x *CookieValue) Reset() {
 	*x = CookieValue{}
-	mi := &file_pkg_proto_http_oidc_oidc_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -49,7 +49,7 @@ func (x *CookieValue) String() string {
 func (*CookieValue) ProtoMessage() {}
 
 func (x *CookieValue) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_http_oidc_oidc_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -62,7 +62,7 @@ func (x *CookieValue) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CookieValue.ProtoReflect.Descriptor instead.
 func (*CookieValue) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_http_oidc_oidc_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *CookieValue) GetSessionState() isCookieValue_SessionState {
@@ -116,7 +116,7 @@ type CookieValue_Authenticating struct {
 
 func (x *CookieValue_Authenticating) Reset() {
 	*x = CookieValue_Authenticating{}
-	mi := &file_pkg_proto_http_oidc_oidc_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -128,7 +128,7 @@ func (x *CookieValue_Authenticating) String() string {
 func (*CookieValue_Authenticating) ProtoMessage() {}
 
 func (x *CookieValue_Authenticating) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_http_oidc_oidc_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -141,7 +141,7 @@ func (x *CookieValue_Authenticating) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CookieValue_Authenticating.ProtoReflect.Descriptor instead.
 func (*CookieValue_Authenticating) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_http_oidc_oidc_proto_rawDescGZIP(), []int{0, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescGZIP(), []int{0, 0}
 }
 
 func (x *CookieValue_Authenticating) GetStateVerifier() []byte {
@@ -170,7 +170,7 @@ type CookieValue_Authenticated struct {
 
 func (x *CookieValue_Authenticated) Reset() {
 	*x = CookieValue_Authenticated{}
-	mi := &file_pkg_proto_http_oidc_oidc_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -182,7 +182,7 @@ func (x *CookieValue_Authenticated) String() string {
 func (*CookieValue_Authenticated) ProtoMessage() {}
 
 func (x *CookieValue_Authenticated) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_http_oidc_oidc_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -195,7 +195,7 @@ func (x *CookieValue_Authenticated) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CookieValue_Authenticated.ProtoReflect.Descriptor instead.
 func (*CookieValue_Authenticated) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_http_oidc_oidc_proto_rawDescGZIP(), []int{0, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescGZIP(), []int{0, 1}
 }
 
 func (x *CookieValue_Authenticated) GetAuthenticationMetadata() *auth.AuthenticationMetadata {
@@ -226,11 +226,11 @@ func (x *CookieValue_Authenticated) GetDefaultExpiration() *durationpb.Duration 
 	return nil
 }
 
-var File_pkg_proto_http_oidc_oidc_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_http_oidc_oidc_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDesc = "" +
 	"\n" +
-	"\x1epkg/proto/http/oidc/oidc.proto\x12\x13buildbarn.http.oidc\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\x19pkg/proto/auth/auth.proto\"\xda\x04\n" +
+	">github.com/buildbarn/bb-storage/pkg/proto/http/oidc/oidc.proto\x12\x13buildbarn.http.oidc\x1a9github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xda\x04\n" +
 	"\vCookieValue\x12Y\n" +
 	"\x0eauthenticating\x18\x01 \x01(\v2/.buildbarn.http.oidc.CookieValue.AuthenticatingH\x00R\x0eauthenticating\x12V\n" +
 	"\rauthenticated\x18\x02 \x01(\v2..buildbarn.http.oidc.CookieValue.AuthenticatedH\x00R\rauthenticated\x1ai\n" +
@@ -247,19 +247,19 @@ const file_pkg_proto_http_oidc_oidc_proto_rawDesc = "" +
 	"\rsession_stateB5Z3github.com/buildbarn/bb-storage/pkg/proto/http/oidcb\x06proto3"
 
 var (
-	file_pkg_proto_http_oidc_oidc_proto_rawDescOnce sync.Once
-	file_pkg_proto_http_oidc_oidc_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescData []byte
 )
 
-func file_pkg_proto_http_oidc_oidc_proto_rawDescGZIP() []byte {
-	file_pkg_proto_http_oidc_oidc_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_http_oidc_oidc_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_http_oidc_oidc_proto_rawDesc), len(file_pkg_proto_http_oidc_oidc_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDesc)))
 	})
-	return file_pkg_proto_http_oidc_oidc_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDescData
 }
 
-var file_pkg_proto_http_oidc_oidc_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
-var file_pkg_proto_http_oidc_oidc_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes = make([]protoimpl.MessageInfo, 3)
+var file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_goTypes = []any{
 	(*CookieValue)(nil),                 // 0: buildbarn.http.oidc.CookieValue
 	(*CookieValue_Authenticating)(nil),  // 1: buildbarn.http.oidc.CookieValue.Authenticating
 	(*CookieValue_Authenticated)(nil),   // 2: buildbarn.http.oidc.CookieValue.Authenticated
@@ -267,7 +267,7 @@ var file_pkg_proto_http_oidc_oidc_proto_goTypes = []any{
 	(*timestamppb.Timestamp)(nil),       // 4: google.protobuf.Timestamp
 	(*durationpb.Duration)(nil),         // 5: google.protobuf.Duration
 }
-var file_pkg_proto_http_oidc_oidc_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_depIdxs = []int32{
 	1, // 0: buildbarn.http.oidc.CookieValue.authenticating:type_name -> buildbarn.http.oidc.CookieValue.Authenticating
 	2, // 1: buildbarn.http.oidc.CookieValue.authenticated:type_name -> buildbarn.http.oidc.CookieValue.Authenticated
 	3, // 2: buildbarn.http.oidc.CookieValue.Authenticated.authentication_metadata:type_name -> buildbarn.auth.AuthenticationMetadata
@@ -280,12 +280,12 @@ var file_pkg_proto_http_oidc_oidc_proto_depIdxs = []int32{
 	0, // [0:5] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_http_oidc_oidc_proto_init() }
-func file_pkg_proto_http_oidc_oidc_proto_init() {
-	if File_pkg_proto_http_oidc_oidc_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto != nil {
 		return
 	}
-	file_pkg_proto_http_oidc_oidc_proto_msgTypes[0].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes[0].OneofWrappers = []any{
 		(*CookieValue_Authenticating_)(nil),
 		(*CookieValue_Authenticated_)(nil),
 	}
@@ -293,17 +293,17 @@ func file_pkg_proto_http_oidc_oidc_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_http_oidc_oidc_proto_rawDesc), len(file_pkg_proto_http_oidc_oidc_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   3,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
-		GoTypes:           file_pkg_proto_http_oidc_oidc_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_http_oidc_oidc_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_http_oidc_oidc_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_http_oidc_oidc_proto = out.File
-	file_pkg_proto_http_oidc_oidc_proto_goTypes = nil
-	file_pkg_proto_http_oidc_oidc_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_http_oidc_oidc_proto_depIdxs = nil
 }

--- a/pkg/proto/http/oidc/oidc.proto
+++ b/pkg/proto/http/oidc/oidc.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package buildbarn.http.oidc;
 
+import "github.com/buildbarn/bb-storage/pkg/proto/auth/auth.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/timestamp.proto";
-import "pkg/proto/auth/auth.proto";
 
 option go_package = "github.com/buildbarn/bb-storage/pkg/proto/http/oidc";
 

--- a/pkg/proto/icas/BUILD.bazel
+++ b/pkg/proto/icas/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "icas_proto",
     srcs = ["icas.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = ["@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_proto"],
 )

--- a/pkg/proto/icas/icas.pb.go
+++ b/pkg/proto/icas/icas.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/icas/icas.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/icas/icas.proto
 
 package icas
 
@@ -40,7 +40,7 @@ type Reference struct {
 
 func (x *Reference) Reset() {
 	*x = Reference{}
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -52,7 +52,7 @@ func (x *Reference) String() string {
 func (*Reference) ProtoMessage() {}
 
 func (x *Reference) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65,7 +65,7 @@ func (x *Reference) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Reference.ProtoReflect.Descriptor instead.
 func (*Reference) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *Reference) GetMedium() isReference_Medium {
@@ -171,7 +171,7 @@ type BatchUpdateReferencesRequest struct {
 
 func (x *BatchUpdateReferencesRequest) Reset() {
 	*x = BatchUpdateReferencesRequest{}
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -183,7 +183,7 @@ func (x *BatchUpdateReferencesRequest) String() string {
 func (*BatchUpdateReferencesRequest) ProtoMessage() {}
 
 func (x *BatchUpdateReferencesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -196,7 +196,7 @@ func (x *BatchUpdateReferencesRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use BatchUpdateReferencesRequest.ProtoReflect.Descriptor instead.
 func (*BatchUpdateReferencesRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *BatchUpdateReferencesRequest) GetInstanceName() string {
@@ -231,7 +231,7 @@ type GetReferenceRequest struct {
 
 func (x *GetReferenceRequest) Reset() {
 	*x = GetReferenceRequest{}
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -243,7 +243,7 @@ func (x *GetReferenceRequest) String() string {
 func (*GetReferenceRequest) ProtoMessage() {}
 
 func (x *GetReferenceRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -256,7 +256,7 @@ func (x *GetReferenceRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetReferenceRequest.ProtoReflect.Descriptor instead.
 func (*GetReferenceRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *GetReferenceRequest) GetInstanceName() string {
@@ -290,7 +290,7 @@ type Reference_S3 struct {
 
 func (x *Reference_S3) Reset() {
 	*x = Reference_S3{}
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -302,7 +302,7 @@ func (x *Reference_S3) String() string {
 func (*Reference_S3) ProtoMessage() {}
 
 func (x *Reference_S3) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -315,7 +315,7 @@ func (x *Reference_S3) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Reference_S3.ProtoReflect.Descriptor instead.
 func (*Reference_S3) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0, 0}
 }
 
 func (x *Reference_S3) GetBucket() string {
@@ -342,7 +342,7 @@ type Reference_GCS struct {
 
 func (x *Reference_GCS) Reset() {
 	*x = Reference_GCS{}
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -354,7 +354,7 @@ func (x *Reference_GCS) String() string {
 func (*Reference_GCS) ProtoMessage() {}
 
 func (x *Reference_GCS) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -367,7 +367,7 @@ func (x *Reference_GCS) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Reference_GCS.ProtoReflect.Descriptor instead.
 func (*Reference_GCS) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0, 1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0, 1}
 }
 
 func (x *Reference_GCS) GetBucket() string {
@@ -395,7 +395,7 @@ type Reference_ContentAddressableStorage struct {
 
 func (x *Reference_ContentAddressableStorage) Reset() {
 	*x = Reference_ContentAddressableStorage{}
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[5]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -407,7 +407,7 @@ func (x *Reference_ContentAddressableStorage) String() string {
 func (*Reference_ContentAddressableStorage) ProtoMessage() {}
 
 func (x *Reference_ContentAddressableStorage) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[5]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[5]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -420,7 +420,7 @@ func (x *Reference_ContentAddressableStorage) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use Reference_ContentAddressableStorage.ProtoReflect.Descriptor instead.
 func (*Reference_ContentAddressableStorage) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0, 2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{0, 2}
 }
 
 func (x *Reference_ContentAddressableStorage) GetInstanceName() string {
@@ -454,7 +454,7 @@ type BatchUpdateReferencesRequest_Request struct {
 
 func (x *BatchUpdateReferencesRequest_Request) Reset() {
 	*x = BatchUpdateReferencesRequest_Request{}
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[6]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -466,7 +466,7 @@ func (x *BatchUpdateReferencesRequest_Request) String() string {
 func (*BatchUpdateReferencesRequest_Request) ProtoMessage() {}
 
 func (x *BatchUpdateReferencesRequest_Request) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_icas_icas_proto_msgTypes[6]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[6]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -479,7 +479,7 @@ func (x *BatchUpdateReferencesRequest_Request) ProtoReflect() protoreflect.Messa
 
 // Deprecated: Use BatchUpdateReferencesRequest_Request.ProtoReflect.Descriptor instead.
 func (*BatchUpdateReferencesRequest_Request) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{1, 0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP(), []int{1, 0}
 }
 
 func (x *BatchUpdateReferencesRequest_Request) GetDigest() *v2.Digest {
@@ -496,11 +496,11 @@ func (x *BatchUpdateReferencesRequest_Request) GetReference() *Reference {
 	return nil
 }
 
-var File_pkg_proto_icas_icas_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_icas_icas_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDesc = "" +
 	"\n" +
-	"\x19pkg/proto/icas/icas.proto\x12\x0ebuildbarn.icas\x1a6build/bazel/remote/execution/v2/remote_execution.proto\"\xff\x05\n" +
+	"9github.com/buildbarn/bb-storage/pkg/proto/icas/icas.proto\x12\x0ebuildbarn.icas\x1a6build/bazel/remote/execution/v2/remote_execution.proto\"\xff\x05\n" +
 	"\tReference\x12\x1b\n" +
 	"\bhttp_url\x18\x01 \x01(\tH\x00R\ahttpUrl\x12.\n" +
 	"\x02s3\x18\x02 \x01(\v2\x1c.buildbarn.icas.Reference.S3H\x00R\x02s3\x121\n" +
@@ -539,19 +539,19 @@ const file_pkg_proto_icas_icas_proto_rawDesc = "" +
 	"\fGetReference\x12#.buildbarn.icas.GetReferenceRequest\x1a\x19.buildbarn.icas.ReferenceB0Z.github.com/buildbarn/bb-storage/pkg/proto/icasb\x06proto3"
 
 var (
-	file_pkg_proto_icas_icas_proto_rawDescOnce sync.Once
-	file_pkg_proto_icas_icas_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescData []byte
 )
 
-func file_pkg_proto_icas_icas_proto_rawDescGZIP() []byte {
-	file_pkg_proto_icas_icas_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_icas_icas_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_icas_icas_proto_rawDesc), len(file_pkg_proto_icas_icas_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDesc)))
 	})
-	return file_pkg_proto_icas_icas_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDescData
 }
 
-var file_pkg_proto_icas_icas_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
-var file_pkg_proto_icas_icas_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes = make([]protoimpl.MessageInfo, 7)
+var file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_goTypes = []any{
 	(*Reference)(nil),                            // 0: buildbarn.icas.Reference
 	(*BatchUpdateReferencesRequest)(nil),         // 1: buildbarn.icas.BatchUpdateReferencesRequest
 	(*GetReferenceRequest)(nil),                  // 2: buildbarn.icas.GetReferenceRequest
@@ -566,7 +566,7 @@ var file_pkg_proto_icas_icas_proto_goTypes = []any{
 	(*v2.FindMissingBlobsResponse)(nil),          // 11: build.bazel.remote.execution.v2.FindMissingBlobsResponse
 	(*v2.BatchUpdateBlobsResponse)(nil),          // 12: build.bazel.remote.execution.v2.BatchUpdateBlobsResponse
 }
-var file_pkg_proto_icas_icas_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_depIdxs = []int32{
 	3,  // 0: buildbarn.icas.Reference.s3:type_name -> buildbarn.icas.Reference.S3
 	4,  // 1: buildbarn.icas.Reference.gcs:type_name -> buildbarn.icas.Reference.GCS
 	5,  // 2: buildbarn.icas.Reference.content_addressable_storage:type_name -> buildbarn.icas.Reference.ContentAddressableStorage
@@ -592,12 +592,12 @@ var file_pkg_proto_icas_icas_proto_depIdxs = []int32{
 	0,  // [0:12] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_icas_icas_proto_init() }
-func file_pkg_proto_icas_icas_proto_init() {
-	if File_pkg_proto_icas_icas_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto != nil {
 		return
 	}
-	file_pkg_proto_icas_icas_proto_msgTypes[0].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes[0].OneofWrappers = []any{
 		(*Reference_HttpUrl)(nil),
 		(*Reference_S3_)(nil),
 		(*Reference_Gcs)(nil),
@@ -607,17 +607,17 @@ func file_pkg_proto_icas_icas_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_icas_icas_proto_rawDesc), len(file_pkg_proto_icas_icas_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   7,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_pkg_proto_icas_icas_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_icas_icas_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_icas_icas_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_icas_icas_proto = out.File
-	file_pkg_proto_icas_icas_proto_goTypes = nil
-	file_pkg_proto_icas_icas_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_icas_icas_proto_depIdxs = nil
 }

--- a/pkg/proto/icas/icas_grpc.pb.go
+++ b/pkg/proto/icas/icas_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.5.1
 // - protoc             v6.31.1
-// source: pkg/proto/icas/icas.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/icas/icas.proto
 
 package icas
 
@@ -192,5 +192,5 @@ var IndirectContentAddressableStorage_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "pkg/proto/icas/icas.proto",
+	Metadata: "github.com/buildbarn/bb-storage/pkg/proto/icas/icas.proto",
 }

--- a/pkg/proto/iscc/BUILD.bazel
+++ b/pkg/proto/iscc/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "iscc_proto",
     srcs = ["iscc.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_proto",

--- a/pkg/proto/iscc/iscc.pb.go
+++ b/pkg/proto/iscc/iscc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/iscc/iscc.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/iscc/iscc.proto
 
 package iscc
 
@@ -39,7 +39,7 @@ type PreviousExecution struct {
 
 func (x *PreviousExecution) Reset() {
 	*x = PreviousExecution{}
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -51,7 +51,7 @@ func (x *PreviousExecution) String() string {
 func (*PreviousExecution) ProtoMessage() {}
 
 func (x *PreviousExecution) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64,7 +64,7 @@ func (x *PreviousExecution) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviousExecution.ProtoReflect.Descriptor instead.
 func (*PreviousExecution) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *PreviousExecution) GetOutcome() isPreviousExecution_Outcome {
@@ -133,7 +133,7 @@ type PerSizeClassStats struct {
 
 func (x *PerSizeClassStats) Reset() {
 	*x = PerSizeClassStats{}
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[1]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -145,7 +145,7 @@ func (x *PerSizeClassStats) String() string {
 func (*PerSizeClassStats) ProtoMessage() {}
 
 func (x *PerSizeClassStats) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[1]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[1]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -158,7 +158,7 @@ func (x *PerSizeClassStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PerSizeClassStats.ProtoReflect.Descriptor instead.
 func (*PerSizeClassStats) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{1}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{1}
 }
 
 func (x *PerSizeClassStats) GetPreviousExecutions() []*PreviousExecution {
@@ -185,7 +185,7 @@ type PreviousExecutionStats struct {
 
 func (x *PreviousExecutionStats) Reset() {
 	*x = PreviousExecutionStats{}
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[2]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -197,7 +197,7 @@ func (x *PreviousExecutionStats) String() string {
 func (*PreviousExecutionStats) ProtoMessage() {}
 
 func (x *PreviousExecutionStats) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[2]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[2]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -210,7 +210,7 @@ func (x *PreviousExecutionStats) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use PreviousExecutionStats.ProtoReflect.Descriptor instead.
 func (*PreviousExecutionStats) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{2}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{2}
 }
 
 func (x *PreviousExecutionStats) GetSizeClasses() map[uint32]*PerSizeClassStats {
@@ -238,7 +238,7 @@ type GetPreviousExecutionStatsRequest struct {
 
 func (x *GetPreviousExecutionStatsRequest) Reset() {
 	*x = GetPreviousExecutionStatsRequest{}
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[3]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -250,7 +250,7 @@ func (x *GetPreviousExecutionStatsRequest) String() string {
 func (*GetPreviousExecutionStatsRequest) ProtoMessage() {}
 
 func (x *GetPreviousExecutionStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[3]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[3]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -263,7 +263,7 @@ func (x *GetPreviousExecutionStatsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetPreviousExecutionStatsRequest.ProtoReflect.Descriptor instead.
 func (*GetPreviousExecutionStatsRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{3}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{3}
 }
 
 func (x *GetPreviousExecutionStatsRequest) GetInstanceName() string {
@@ -299,7 +299,7 @@ type UpdatePreviousExecutionStatsRequest struct {
 
 func (x *UpdatePreviousExecutionStatsRequest) Reset() {
 	*x = UpdatePreviousExecutionStatsRequest{}
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[4]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -311,7 +311,7 @@ func (x *UpdatePreviousExecutionStatsRequest) String() string {
 func (*UpdatePreviousExecutionStatsRequest) ProtoMessage() {}
 
 func (x *UpdatePreviousExecutionStatsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_iscc_iscc_proto_msgTypes[4]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[4]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -324,7 +324,7 @@ func (x *UpdatePreviousExecutionStatsRequest) ProtoReflect() protoreflect.Messag
 
 // Deprecated: Use UpdatePreviousExecutionStatsRequest.ProtoReflect.Descriptor instead.
 func (*UpdatePreviousExecutionStatsRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{4}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescGZIP(), []int{4}
 }
 
 func (x *UpdatePreviousExecutionStatsRequest) GetInstanceName() string {
@@ -355,11 +355,11 @@ func (x *UpdatePreviousExecutionStatsRequest) GetDigestFunction() v2.DigestFunct
 	return v2.DigestFunction_Value(0)
 }
 
-var File_pkg_proto_iscc_iscc_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_iscc_iscc_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDesc = "" +
 	"\n" +
-	"\x19pkg/proto/iscc/iscc.proto\x12\x0ebuildbarn.iscc\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc5\x01\n" +
+	"9github.com/buildbarn/bb-storage/pkg/proto/iscc/iscc.proto\x12\x0ebuildbarn.iscc\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1egoogle/protobuf/duration.proto\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc5\x01\n" +
 	"\x11PreviousExecution\x120\n" +
 	"\x06failed\x18\x01 \x01(\v2\x16.google.protobuf.EmptyH\x00R\x06failed\x128\n" +
 	"\ttimed_out\x18\x02 \x01(\v2\x19.google.protobuf.DurationH\x00R\btimedOut\x129\n" +
@@ -388,19 +388,19 @@ const file_pkg_proto_iscc_iscc_proto_rawDesc = "" +
 	"\x1cUpdatePreviousExecutionStats\x123.buildbarn.iscc.UpdatePreviousExecutionStatsRequest\x1a\x16.google.protobuf.EmptyB0Z.github.com/buildbarn/bb-storage/pkg/proto/isccb\x06proto3"
 
 var (
-	file_pkg_proto_iscc_iscc_proto_rawDescOnce sync.Once
-	file_pkg_proto_iscc_iscc_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescData []byte
 )
 
-func file_pkg_proto_iscc_iscc_proto_rawDescGZIP() []byte {
-	file_pkg_proto_iscc_iscc_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_iscc_iscc_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_iscc_iscc_proto_rawDesc), len(file_pkg_proto_iscc_iscc_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDesc)))
 	})
-	return file_pkg_proto_iscc_iscc_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDescData
 }
 
-var file_pkg_proto_iscc_iscc_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
-var file_pkg_proto_iscc_iscc_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_goTypes = []any{
 	(*PreviousExecution)(nil),                   // 0: buildbarn.iscc.PreviousExecution
 	(*PerSizeClassStats)(nil),                   // 1: buildbarn.iscc.PerSizeClassStats
 	(*PreviousExecutionStats)(nil),              // 2: buildbarn.iscc.PreviousExecutionStats
@@ -413,7 +413,7 @@ var file_pkg_proto_iscc_iscc_proto_goTypes = []any{
 	(*v2.Digest)(nil),             // 9: build.bazel.remote.execution.v2.Digest
 	(v2.DigestFunction_Value)(0),  // 10: build.bazel.remote.execution.v2.DigestFunction.Value
 }
-var file_pkg_proto_iscc_iscc_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_depIdxs = []int32{
 	6,  // 0: buildbarn.iscc.PreviousExecution.failed:type_name -> google.protobuf.Empty
 	7,  // 1: buildbarn.iscc.PreviousExecution.timed_out:type_name -> google.protobuf.Duration
 	7,  // 2: buildbarn.iscc.PreviousExecution.succeeded:type_name -> google.protobuf.Duration
@@ -437,12 +437,12 @@ var file_pkg_proto_iscc_iscc_proto_depIdxs = []int32{
 	0,  // [0:12] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_iscc_iscc_proto_init() }
-func file_pkg_proto_iscc_iscc_proto_init() {
-	if File_pkg_proto_iscc_iscc_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto != nil {
 		return
 	}
-	file_pkg_proto_iscc_iscc_proto_msgTypes[0].OneofWrappers = []any{
+	file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes[0].OneofWrappers = []any{
 		(*PreviousExecution_Failed)(nil),
 		(*PreviousExecution_TimedOut)(nil),
 		(*PreviousExecution_Succeeded)(nil),
@@ -451,17 +451,17 @@ func file_pkg_proto_iscc_iscc_proto_init() {
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_iscc_iscc_proto_rawDesc), len(file_pkg_proto_iscc_iscc_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_pkg_proto_iscc_iscc_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_iscc_iscc_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_iscc_iscc_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_iscc_iscc_proto = out.File
-	file_pkg_proto_iscc_iscc_proto_goTypes = nil
-	file_pkg_proto_iscc_iscc_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_iscc_iscc_proto_depIdxs = nil
 }

--- a/pkg/proto/iscc/iscc_grpc.pb.go
+++ b/pkg/proto/iscc/iscc_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.5.1
 // - protoc             v6.31.1
-// source: pkg/proto/iscc/iscc.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/iscc/iscc.proto
 
 package iscc
 
@@ -154,5 +154,5 @@ var InitialSizeClassCache_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "pkg/proto/iscc/iscc.proto",
+	Metadata: "github.com/buildbarn/bb-storage/pkg/proto/iscc/iscc.proto",
 }

--- a/pkg/proto/replicator/BUILD.bazel
+++ b/pkg/proto/replicator/BUILD.bazel
@@ -5,6 +5,7 @@ load("@rules_proto//proto:defs.bzl", "proto_library")
 proto_library(
     name = "replicator_proto",
     srcs = ["replicator.proto"],
+    import_prefix = "github.com/buildbarn/bb-storage",
     visibility = ["//visibility:public"],
     deps = [
         "@bazel_remote_apis//build/bazel/remote/execution/v2:remote_execution_proto",

--- a/pkg/proto/replicator/replicator.pb.go
+++ b/pkg/proto/replicator/replicator.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // 	protoc-gen-go v1.36.9
 // 	protoc        v6.31.1
-// source: pkg/proto/replicator/replicator.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/replicator/replicator.proto
 
 package replicator
 
@@ -34,7 +34,7 @@ type ReplicateBlobsRequest struct {
 
 func (x *ReplicateBlobsRequest) Reset() {
 	*x = ReplicateBlobsRequest{}
-	mi := &file_pkg_proto_replicator_replicator_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_msgTypes[0]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -46,7 +46,7 @@ func (x *ReplicateBlobsRequest) String() string {
 func (*ReplicateBlobsRequest) ProtoMessage() {}
 
 func (x *ReplicateBlobsRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_pkg_proto_replicator_replicator_proto_msgTypes[0]
+	mi := &file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_msgTypes[0]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -59,7 +59,7 @@ func (x *ReplicateBlobsRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use ReplicateBlobsRequest.ProtoReflect.Descriptor instead.
 func (*ReplicateBlobsRequest) Descriptor() ([]byte, []int) {
-	return file_pkg_proto_replicator_replicator_proto_rawDescGZIP(), []int{0}
+	return file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDescGZIP(), []int{0}
 }
 
 func (x *ReplicateBlobsRequest) GetInstanceName() string {
@@ -83,11 +83,11 @@ func (x *ReplicateBlobsRequest) GetDigestFunction() v2.DigestFunction_Value {
 	return v2.DigestFunction_Value(0)
 }
 
-var File_pkg_proto_replicator_replicator_proto protoreflect.FileDescriptor
+var File_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto protoreflect.FileDescriptor
 
-const file_pkg_proto_replicator_replicator_proto_rawDesc = "" +
+const file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDesc = "" +
 	"\n" +
-	"%pkg/proto/replicator/replicator.proto\x12\x14buildbarn.replicator\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xe8\x01\n" +
+	"Egithub.com/buildbarn/bb-storage/pkg/proto/replicator/replicator.proto\x12\x14buildbarn.replicator\x1a6build/bazel/remote/execution/v2/remote_execution.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xe8\x01\n" +
 	"\x15ReplicateBlobsRequest\x12#\n" +
 	"\rinstance_name\x18\x01 \x01(\tR\finstanceName\x12J\n" +
 	"\fblob_digests\x18\x02 \x03(\v2'.build.bazel.remote.execution.v2.DigestR\vblobDigests\x12^\n" +
@@ -97,25 +97,25 @@ const file_pkg_proto_replicator_replicator_proto_rawDesc = "" +
 	"\x0eReplicateBlobs\x12+.buildbarn.replicator.ReplicateBlobsRequest\x1a\x16.google.protobuf.EmptyB6Z4github.com/buildbarn/bb-storage/pkg/proto/replicatorb\x06proto3"
 
 var (
-	file_pkg_proto_replicator_replicator_proto_rawDescOnce sync.Once
-	file_pkg_proto_replicator_replicator_proto_rawDescData []byte
+	file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDescOnce sync.Once
+	file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDescData []byte
 )
 
-func file_pkg_proto_replicator_replicator_proto_rawDescGZIP() []byte {
-	file_pkg_proto_replicator_replicator_proto_rawDescOnce.Do(func() {
-		file_pkg_proto_replicator_replicator_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_pkg_proto_replicator_replicator_proto_rawDesc), len(file_pkg_proto_replicator_replicator_proto_rawDesc)))
+func file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDescGZIP() []byte {
+	file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDescOnce.Do(func() {
+		file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDescData = protoimpl.X.CompressGZIP(unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDesc)))
 	})
-	return file_pkg_proto_replicator_replicator_proto_rawDescData
+	return file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDescData
 }
 
-var file_pkg_proto_replicator_replicator_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
-var file_pkg_proto_replicator_replicator_proto_goTypes = []any{
+var file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
+var file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_goTypes = []any{
 	(*ReplicateBlobsRequest)(nil), // 0: buildbarn.replicator.ReplicateBlobsRequest
 	(*v2.Digest)(nil),             // 1: build.bazel.remote.execution.v2.Digest
 	(v2.DigestFunction_Value)(0),  // 2: build.bazel.remote.execution.v2.DigestFunction.Value
 	(*emptypb.Empty)(nil),         // 3: google.protobuf.Empty
 }
-var file_pkg_proto_replicator_replicator_proto_depIdxs = []int32{
+var file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_depIdxs = []int32{
 	1, // 0: buildbarn.replicator.ReplicateBlobsRequest.blob_digests:type_name -> build.bazel.remote.execution.v2.Digest
 	2, // 1: buildbarn.replicator.ReplicateBlobsRequest.digest_function:type_name -> build.bazel.remote.execution.v2.DigestFunction.Value
 	0, // 2: buildbarn.replicator.Replicator.ReplicateBlobs:input_type -> buildbarn.replicator.ReplicateBlobsRequest
@@ -127,26 +127,26 @@ var file_pkg_proto_replicator_replicator_proto_depIdxs = []int32{
 	0, // [0:2] is the sub-list for field type_name
 }
 
-func init() { file_pkg_proto_replicator_replicator_proto_init() }
-func file_pkg_proto_replicator_replicator_proto_init() {
-	if File_pkg_proto_replicator_replicator_proto != nil {
+func init() { file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_init() }
+func file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_init() {
+	if File_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto != nil {
 		return
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
-			RawDescriptor: unsafe.Slice(unsafe.StringData(file_pkg_proto_replicator_replicator_proto_rawDesc), len(file_pkg_proto_replicator_replicator_proto_rawDesc)),
+			RawDescriptor: unsafe.Slice(unsafe.StringData(file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDesc), len(file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   1,
 		},
-		GoTypes:           file_pkg_proto_replicator_replicator_proto_goTypes,
-		DependencyIndexes: file_pkg_proto_replicator_replicator_proto_depIdxs,
-		MessageInfos:      file_pkg_proto_replicator_replicator_proto_msgTypes,
+		GoTypes:           file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_goTypes,
+		DependencyIndexes: file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_depIdxs,
+		MessageInfos:      file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_msgTypes,
 	}.Build()
-	File_pkg_proto_replicator_replicator_proto = out.File
-	file_pkg_proto_replicator_replicator_proto_goTypes = nil
-	file_pkg_proto_replicator_replicator_proto_depIdxs = nil
+	File_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto = out.File
+	file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_goTypes = nil
+	file_github_com_buildbarn_bb_storage_pkg_proto_replicator_replicator_proto_depIdxs = nil
 }

--- a/pkg/proto/replicator/replicator_grpc.pb.go
+++ b/pkg/proto/replicator/replicator_grpc.pb.go
@@ -2,7 +2,7 @@
 // versions:
 // - protoc-gen-go-grpc v1.5.1
 // - protoc             v6.31.1
-// source: pkg/proto/replicator/replicator.proto
+// source: github.com/buildbarn/bb-storage/pkg/proto/replicator/replicator.proto
 
 package replicator
 
@@ -116,5 +116,5 @@ var Replicator_ServiceDesc = grpc.ServiceDesc{
 		},
 	},
 	Streams:  []grpc.StreamDesc{},
-	Metadata: "pkg/proto/replicator/replicator.proto",
+	Metadata: "github.com/buildbarn/bb-storage/pkg/proto/replicator/replicator.proto",
 }


### PR DESCRIPTION
If we do this across all of our repos, it should be a lot easier for people to discover where other .proto files may be found. Maybe it'll also allow us to get rid of the gazelle:resolve directives we have in other repos.