### PR TITLE
fix: prevent double-close inflating zstd pool release counters

### DIFF
--- a/pkg/blobstore/grpcservers/byte_stream_server.go
+++ b/pkg/blobstore/grpcservers/byte_stream_server.go
@@ -222,7 +222,6 @@ func (s *byteStreamServer) writeZstd(stream bytestream.ByteStream_WriteServer, r
 	if err != nil {
 		return status.Errorf(codes.ResourceExhausted, "Failed to acquire ZSTD decoder: %v", err)
 	}
-	defer zstdReader.Close()
 
 	if err := s.blobAccess.Put(
 		ctx,

--- a/pkg/blobstore/grpcservers/byte_stream_server.go
+++ b/pkg/blobstore/grpcservers/byte_stream_server.go
@@ -9,6 +9,7 @@ import (
 	"github.com/buildbarn/bb-storage/pkg/blobstore"
 	"github.com/buildbarn/bb-storage/pkg/blobstore/buffer"
 	"github.com/buildbarn/bb-storage/pkg/digest"
+	"github.com/buildbarn/bb-storage/pkg/util"
 	bb_zstd "github.com/buildbarn/bb-storage/pkg/zstd"
 
 	"google.golang.org/genproto/googleapis/bytestream"
@@ -220,7 +221,7 @@ func (s *byteStreamServer) writeZstd(stream bytestream.ByteStream_WriteServer, r
 
 	zstdReader, err := bb_zstd.NewReadCloser(ctx, s.zstdPool, streamReader)
 	if err != nil {
-		return status.Errorf(codes.ResourceExhausted, "Failed to acquire ZSTD decoder: %v", err)
+		return util.StatusWrap(err, "Failed to acquire ZSTD decoder")
 	}
 
 	if err := s.blobAccess.Put(

--- a/pkg/zstd/metrics_pool.go
+++ b/pkg/zstd/metrics_pool.go
@@ -123,15 +123,14 @@ func (p *metricsPool) NewDecoder(ctx context.Context, r io.Reader) (Decoder, err
 type metricsEncoder struct {
 	Encoder
 	releases prometheus.Counter
-	closed   bool
 }
 
 func (e *metricsEncoder) Close() error {
-	if e.closed {
+	if e.Encoder == nil {
 		return nil
 	}
-	e.closed = true
 	err := e.Encoder.Close()
+	e.Encoder = nil
 	e.releases.Inc()
 	return err
 }
@@ -139,14 +138,13 @@ func (e *metricsEncoder) Close() error {
 type metricsDecoder struct {
 	Decoder
 	releases prometheus.Counter
-	closed   bool
 }
 
 func (d *metricsDecoder) Close() {
-	if d.closed {
+	if d.Decoder == nil {
 		return
 	}
-	d.closed = true
 	d.Decoder.Close()
+	d.Decoder = nil
 	d.releases.Inc()
 }

--- a/pkg/zstd/metrics_pool.go
+++ b/pkg/zstd/metrics_pool.go
@@ -123,9 +123,14 @@ func (p *metricsPool) NewDecoder(ctx context.Context, r io.Reader) (Decoder, err
 type metricsEncoder struct {
 	Encoder
 	releases prometheus.Counter
+	closed   bool
 }
 
 func (e *metricsEncoder) Close() error {
+	if e.closed {
+		return nil
+	}
+	e.closed = true
 	err := e.Encoder.Close()
 	e.releases.Inc()
 	return err
@@ -134,9 +139,14 @@ func (e *metricsEncoder) Close() error {
 type metricsDecoder struct {
 	Decoder
 	releases prometheus.Counter
+	closed   bool
 }
 
 func (d *metricsDecoder) Close() {
+	if d.closed {
+		return
+	}
+	d.closed = true
 	d.Decoder.Close()
 	d.releases.Inc()
 }


### PR DESCRIPTION
## Summary

Hey @EdSchouten, firstly I want to say that overall in our testing, the changes from #327 have been working very well! A tremendous thank you for taking your time to work with me and refine this approach into a very nice technical solution 🥳

<img width="1504" height="524" alt="image" src="https://github.com/user-attachments/assets/5957eff2-a8a1-431f-950b-8d01e206ba88" />


After integrating with the new metrics available, I've noticed that the observed releases did not match the observed acquisitions. This PR introduces a patch fix for this issue.

- Remove redundant `defer zstdReader.Close()` in `writeZstd()`, the buffer takes ownership of the reader via `NewCASBufferFromReader` and closes it, so the defer was a second close
- Add double-close guards to `metricsEncoder.Close()` and `metricsDecoder.Close()` as a safety net, matching the existing pattern in `pooledEncoder`/`pooledDecoder`

The `writeZstd()` path double-closes the decoder: once when the buffer consumes and closes the reader, and again via `defer`. Since `metricsDecoder.Close()` lacks double-close protection (unlike the underlying `pooledDecoder`), each compressed ByteStream write increments `releases_total` an extra time. Over time this causes `releases_total` to permanently exceed `acquisitions_total` (observed: 336,865 releases vs 333,001 acquisitions = 3,864 excess, corresponding to the number of compressed ByteStream writes).

## Test plan

- [x] `bazel test //pkg/zstd/... //pkg/blobstore/grpcservers/...` — all pass
- [x] `bazel test //...` — all 30 tests pass
- [ ] Verify `releases_total` no longer exceeds `acquisitions_total` after deployment