### PR TITLE
Fix gRPC reflection for local services

### DIFF
--- a/pkg/grpc/reflection_relay.go
+++ b/pkg/grpc/reflection_relay.go
@@ -44,7 +44,10 @@ func registerReflectionServer(backendCtx context.Context, s *grpc.Server, server
 	}
 
 	// Make a combined descriptor and extension resolver.
-	reflectionBackends := []protoresolve.Resolver{}
+	reflectionBackends := []protoresolve.Resolver{
+		// First serve our own services.
+		protoresolve.GlobalDescriptors,
+	}
 	for _, relay := range serverRelayConfigurations {
 		resolver := grpcreflect.NewClientAuto(backendCtx, relay.grpcClient).AsResolver()
 		reflectionBackends = append(reflectionBackends, resolver)


### PR DESCRIPTION
Commit 5b5db75d620841b08c02f04f817652d4ebc949ce,
"Add generic gRPC stream forwarding (#306)",
correctly added forwarding of grpc_reflection_v1 to configured backends. Unfortunately, it stopped the local services from being reported.