### PR TITLE
program: exit(0) directly in terminateWithSignal to avoid runtime exit(2)

### DIFF
--- a/cmd/bb_replicator/main.go
+++ b/cmd/bb_replicator/main.go
@@ -75,5 +75,5 @@ func main() {
 
 		lifecycleState.MarkReadyAndWait(siblingsGroup)
 		return nil
-	})
+	}, program.WithDaemonExit())
 }

--- a/cmd/bb_storage/main.go
+++ b/cmd/bb_storage/main.go
@@ -247,7 +247,7 @@ func main() {
 
 		lifecycleState.MarkReadyAndWait(siblingsGroup)
 		return nil
-	})
+	}, program.WithDaemonExit())
 }
 
 func newNonScannableBlobAccess(dependenciesGroup program.Group, configuration *bb_storage.NonScannableBlobAccessConfiguration, creator blobstore_configuration.BlobAccessCreator, grpcClientFactory bb_grpc.ClientFactory) (blobstore_configuration.BlobAccessInfo, blobstore.BlobAccess, []auth.Authorizer, auth.Authorizer, error) {

--- a/pkg/program/run_main.go
+++ b/pkg/program/run_main.go
@@ -8,7 +8,6 @@ import (
 	"runtime"
 	"sync"
 	"syscall"
-	"time"
 )
 
 // runMainErrorLogger is used by RunMain() to capture errors returned by
@@ -34,40 +33,66 @@ func (el *runMainErrorLogger) startShutdown(shutdownFunc func()) {
 	})
 }
 
-// terminateWithSignal terminates the current process by sending a
-// signal to itself.
-func terminateWithSignal(currentPID int, terminationSignal os.Signal) {
+// runMainConfig collects the optional behaviours of RunMain. Constructed
+// internally; callers populate it via Option values.
+type runMainConfig struct {
+	daemon bool
+}
+
+// Option configures RunMain.
+type Option func(*runMainConfig)
+
+// WithDaemonExit causes a signal-triggered graceful shutdown to exit 0
+// instead of 128+signal. Use this for long-running daemons (servers,
+// workers, schedulers) where SIGINT/SIGTERM is the expected lifecycle
+// event and a clean wind-down should look successful to the supervising
+// process (k8s pod phase Succeeded, systemd inactive (dead) without
+// failure).
+//
+// Without this option (the default), signal interruption exits with the
+// POSIX-conventional 128+signal so wrapper scripts and init systems can
+// distinguish a completed run from one that was interrupted mid-work.
+// This is the right behaviour for one-shot CLI tools (bb_copy,
+// sync_jwks_to_configmap, etc.).
+func WithDaemonExit() Option {
+	return func(c *runMainConfig) { c.daemon = true }
+}
+
+// terminateWithSignal completes a shutdown initiated by terminationSignal.
+//
+// Previously this re-raised the signal back to the process via
+// signal.Reset() + process.Signal() so the container/init system would
+// observe a signal-style exit (e.g. 128+SIGTERM=143). signal.Reset()
+// does not install SIG_DFL though — the runtime's signal trampoline
+// still catches the raised signal and dispatches to
+// runtime.dieFromSignal(), which falls through to a hard exit(2) when
+// its signal-to-self races. Multi-goroutine programs running as PID 1
+// in a PID namespace reliably hit that fall-through, surfacing exit 2
+// despite a clean shutdown.
+//
+// Skip the signal-raise dance and exit with the right code directly.
+// 128+signal is what POSIX shells (bash, zsh) and init systems
+// (systemd, kubelet) report from WIFSIGNALED anyway, so the
+// user-visible exit is equivalent without going near Go's signal
+// machinery. Daemons opt into exit 0 via WithDaemonExit so a graceful
+// shutdown via SIGTERM does not look like a failure to the supervisor.
+//
+// Refs:
+//   - https://github.com/golang/go/issues/19326
+//   - https://github.com/golang/go/issues/46321
+func terminateWithSignal(currentPID int, terminationSignal os.Signal, daemon bool) {
+	if daemon {
+		os.Exit(0)
+	}
 	if runtime.GOOS == "windows" {
-		// On Windows, process.Signal() is not supported so
-		// immediately exit.
+		// On Windows, process.Signal() is not supported and
+		// signal numbers do not map to POSIX exit codes; just
+		// exit non-zero so wrapper scripts see the interruption.
 		os.Exit(1)
 	}
-
-	// Clear the signal handler and raise the
-	// original signal once again. That way we shut
-	// down under the original circumstances.
-	signal.Reset(terminationSignal)
-	process, err := os.FindProcess(currentPID)
-	if err != nil {
-		panic(err)
+	if sig, ok := terminationSignal.(syscall.Signal); ok {
+		os.Exit(128 + int(sig))
 	}
-	if err := process.Signal(terminationSignal); err != nil {
-		panic(err)
-	}
-
-	// This code should not be reached, if it weren't for the fact
-	// that process.Signal() does not guarantee that the signal is
-	// delivered to the same thread.
-	//
-	// Furthermore, signal.Reset() does not reset signals that are
-	// delivered via the process group, but ignored by the process
-	// itself. Fall back to calling os.Exit() if we don't get
-	// terminated via signal delivery.
-	//
-	// More details:
-	// https://github.com/golang/go/issues/19326
-	// https://github.com/golang/go/issues/46321
-	time.Sleep(5)
 	os.Exit(1)
 }
 
@@ -86,16 +111,24 @@ var terminationSignals = []os.Signal{
 //   - One of the routines fails with a non-nil error. In that case the
 //     program terminates with exit code 1.
 //
-//   - The program receives SIGINT or SIGTERM. In that case the program
-//     will terminate with that signal.
+//   - The program receives SIGINT or SIGTERM. By default the program
+//     terminates with exit code 128+signal (the POSIX convention),
+//     which is appropriate for one-shot tools. Pass WithDaemonExit to
+//     exit 0 instead — appropriate for long-running daemons where a
+//     signal-triggered shutdown is the normal lifecycle.
 //
 // In case termination occurs, all remaining routines are canceled,
 // respecting dependencies between these routines. This can for example
 // be used to ensure an outgoing database connection is terminated after
 // an integrated RPC server is shut down.
-func RunMain(routine Routine) {
+func RunMain(routine Routine, opts ...Option) {
+	var cfg runMainConfig
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
 	currentPID := os.Getpid()
-	relaunchIfPID1(currentPID)
+	relaunchIfPID1(currentPID, cfg.daemon)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	errorLogger := &runMainErrorLogger{
@@ -109,7 +142,7 @@ func RunMain(routine Routine) {
 		receivedSignal := <-signalChan
 		log.Printf("Received %#v signal. Initiating graceful shutdown.", receivedSignal.String())
 		errorLogger.startShutdown(func() {
-			terminateWithSignal(currentPID, receivedSignal)
+			terminateWithSignal(currentPID, receivedSignal, cfg.daemon)
 		})
 	}()
 

--- a/pkg/program/run_main_linux.go
+++ b/pkg/program/run_main_linux.go
@@ -22,7 +22,7 @@ import (
 // to terminate, we need to run multiple processes.
 //
 // More details: https://github.com/golang/go/pull/61261
-func relaunchIfPID1(currentPID int) {
+func relaunchIfPID1(currentPID int, daemon bool) {
 	if currentPID == 1 {
 		executable, err := os.Executable()
 		if err != nil {
@@ -62,7 +62,7 @@ func relaunchIfPID1(currentPID int) {
 
 			if waitedPID == childPID {
 				if status.Signaled() {
-					terminateWithSignal(currentPID, status.Signal())
+					terminateWithSignal(currentPID, status.Signal(), daemon)
 				}
 				os.Exit(status.ExitStatus())
 			}

--- a/pkg/program/run_main_other.go
+++ b/pkg/program/run_main_other.go
@@ -2,4 +2,4 @@
 
 package program
 
-func relaunchIfPID1(currentPID int) {}
+func relaunchIfPID1(currentPID int, daemon bool) {}


### PR DESCRIPTION
## Problem

`terminateWithSignal()` re-raises the original signal back to the process via `signal.Reset()` + `process.Signal()` to mimic a signal-style exit (e.g. `128+SIGTERM=143`). But `signal.Reset()` does not install `SIG_DFL`, it only disables Go's user-channel routing. The runtime's signal trampoline is still installed and intercepts the raised signal, dispatching it to `runtime.dieFromSignal()`:

```
raise(sig); osyield x3; setsig(sig, _SIG_DFL); raise(sig); osyield x3; exit(2)
```

Multi-goroutine programs running as PID 1 in a PID namespace reliably hit the `exit(2)` fall-through. `bb_worker` and other daemons exit code 2 on graceful SIGTERM despite a clean shutdown, pods end Failed/Error in k8s. The existing `time.Sleep + os.Exit` fallback was unreachable code (and `time.Sleep(5)` is 5 nanoseconds anyway).

## Approach

Skip the signal-raise dance and exit with the right code directly. `128+signal` is what POSIX shells and init systems derive from `WIFSIGNALED`, so it's user-visibly equivalent without going near Go's signal machinery.

Per review feedback: exit `128+signal` is correct for one-shot tools (`bb_copy`, `sync_jwks_to_configmap`) where signal interruption should leave a non-zero status, but wrong for daemons where graceful shutdown should look successful to the supervisor (k8s pod phase `Succeeded`, systemd inactive (dead) without failure).

Add a variadic `Option` to `RunMain`:

- Default, exit `128+signal` (correct for one-shot CLI tools)
- `program.WithDaemonExit()`, exit `0` (correct for long-running daemons)

Migrate this repo's daemons (`bb_storage`, `bb_replicator`) in the same PR; leave `bb_copy` and `sync_jwks_to_configmap` unchanged. Cross-repo daemons (`bb_worker`, `bb_scheduler`, `bb_runner` in `bb-remote-execution`; `bb_autoscaler` elsewhere) pick the daemon variant matching their lifecycle when they bump the dependency.

## Refs

- https://github.com/golang/go/issues/19326
- https://github.com/golang/go/issues/46321