### PR TITLE
perf: reduce allocations on the digest and buffer hot paths

### DIFF
--- a/pkg/blobstore/buffer/cas_reader_buffer.go
+++ b/pkg/blobstore/buffer/cas_reader_buffer.go
@@ -80,7 +80,24 @@ func (b *casReaderBuffer) ToByteSlice(maximumSizeBytes int) ([]byte, error) {
 	if expectedSizeBytes > int64(maximumSizeBytes) {
 		return nil, status.Errorf(codes.InvalidArgument, "Buffer is %d bytes in size, while a maximum of %d bytes is permitted", expectedSizeBytes, maximumSizeBytes)
 	}
-	return io.ReadAll(r)
+	// Allocate the result buffer up front, as the size is already
+	// known. This avoids the repeated reallocation and redundant
+	// memcpy that io.ReadAll() would perform.
+	data := make([]byte, expectedSizeBytes)
+	if expectedSizeBytes > 0 {
+		if _, err := io.ReadFull(r, data); err != nil {
+			return nil, err
+		}
+		return data, nil
+	}
+	// io.ReadFull() returns immediately for a zero-length buffer
+	// without invoking the underlying reader. Issue a single Read()
+	// so that the validating reader still gets a chance to check
+	// the size and checksum of empty blobs.
+	if _, err := r.Read(nil); err != nil && err != io.EOF {
+		return nil, err
+	}
+	return data, nil
 }
 
 func (b *casReaderBuffer) ToChunkReader(off int64, maximumChunkSizeBytes int) ChunkReader {

--- a/pkg/blobstore/buffer/validated_reader_at_buffer.go
+++ b/pkg/blobstore/buffer/validated_reader_at_buffer.go
@@ -67,7 +67,14 @@ func (b *validatedReaderBuffer) ToByteSlice(maximumSizeBytes int) ([]byte, error
 	if b.sizeBytes > int64(maximumSizeBytes) {
 		return nil, status.Errorf(codes.InvalidArgument, "Buffer is %d bytes in size, while a maximum of %d bytes is permitted", b.sizeBytes, maximumSizeBytes)
 	}
-	return io.ReadAll(io.NewSectionReader(b.r, 0, b.sizeBytes))
+	// Allocate the result buffer up front, as the size is already
+	// known. This avoids the repeated reallocation and redundant
+	// memcpy that io.ReadAll() would perform.
+	data := make([]byte, b.sizeBytes)
+	if _, err := io.ReadFull(io.NewSectionReader(b.r, 0, b.sizeBytes), data); err != nil {
+		return nil, err
+	}
+	return data, nil
 }
 
 func (b *validatedReaderBuffer) ToChunkReader(off int64, maximumChunkSizeBytes int) ChunkReader {

--- a/pkg/blobstore/completenesschecking/completeness_checking_blob_access.go
+++ b/pkg/blobstore/completenesschecking/completeness_checking_blob_access.go
@@ -52,7 +52,7 @@ func (q *findMissingQueue) add(blobDigest *remoteexecution.Digest) error {
 			if err := q.finalize(); err != nil {
 				return err
 			}
-			q.pending = digest.NewSetBuilder()
+			q.pending = digest.NewSetBuilder(q.batchSize)
 		}
 		q.pending.Add(derivedDigest)
 	}
@@ -109,7 +109,7 @@ func (ba *completenessCheckingBlobAccess) checkCompleteness(ctx context.Context,
 		digestFunction:            digestFunction,
 		contentAddressableStorage: ba.contentAddressableStorage,
 		batchSize:                 ba.batchSize,
-		pending:                   digest.NewSetBuilder(),
+		pending:                   digest.NewSetBuilder(ba.batchSize),
 	}
 
 	// Iterate over all remoteexecution.Digest fields contained

--- a/pkg/blobstore/completenesschecking/completeness_checking_blob_access_test.go
+++ b/pkg/blobstore/completenesschecking/completeness_checking_blob_access_test.go
@@ -87,7 +87,7 @@ func TestCompletenessCheckingBlobAccess(t *testing.T) {
 				buffer.BackendProvided(dataIntegrityCallback.Call)))
 		contentAddressableStorage.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Build(),
@@ -253,7 +253,7 @@ func TestCompletenessCheckingBlobAccess(t *testing.T) {
 			buffer.NewCASBufferFromReader(treeDigest, treeReader, buffer.BackendProvided(dataIntegrityCallback2.Call)))
 		contentAddressableStorage.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(treeDigest).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "024ced29f1fdef2f644f34a071ade5be", 1)).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "8b3b146b1c4df062a2dc35168cbf4ce6", 2)).
@@ -369,7 +369,7 @@ func TestCompletenessCheckingBlobAccess(t *testing.T) {
 		}, buffer.BackendProvided(dataIntegrityCallback2.Call)))
 		contentAddressableStorage.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "38837949e2518a6e8a912ffb29942788", 10)).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "ebbbb099e9d2f7892d97ab3640ae8283", 9)).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 200)).
@@ -379,7 +379,7 @@ func TestCompletenessCheckingBlobAccess(t *testing.T) {
 		).Return(digest.EmptySet, nil)
 		contentAddressableStorage.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "41d7247285b686496aa91b56b4c48395", 11)).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "eda14e187a768b38eda999457c9cca1e", 6)).
 				Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "bdcfcea2c9e3d753463abd000dab2495", 40)).

--- a/pkg/blobstore/demultiplexing_blob_access.go
+++ b/pkg/blobstore/demultiplexing_blob_access.go
@@ -92,7 +92,7 @@ func (ba *demultiplexingBlobAccess) FindMissing(ctx context.Context, digests dig
 			if !ok {
 				// This backend hasn't been observed before.
 				partition = &partitionInfo{
-					digests: digest.NewSetBuilder(),
+					digests: digest.NewSetBuilder(0),
 					backend: backend,
 					patcher: patcher,
 				}
@@ -111,7 +111,7 @@ func (ba *demultiplexingBlobAccess) FindMissing(ctx context.Context, digests dig
 	// Right now we don't really see calls with multiple instance
 	// names, meaning it wouldn't help. This may change in the
 	// future.
-	allMissing := digest.NewSetBuilder()
+	allMissing := digest.NewSetBuilder(0)
 	for backendName, partition := range perBackendPartitions {
 		partitionMissing, err := partition.backend.FindMissing(ctx, partition.digests.Build())
 		if err != nil {

--- a/pkg/blobstore/demultiplexing_blob_access_test.go
+++ b/pkg/blobstore/demultiplexing_blob_access_test.go
@@ -267,7 +267,7 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 			nil)
 		baseBlobAccess.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("goodbye/world", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("goodbye/world", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Build()).
@@ -275,7 +275,7 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 
 		_, err := blobAccess.FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("hello/world", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("hello/world", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Build())
@@ -320,28 +320,28 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 			nil)
 		baseBlobAccessA.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("A", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("A", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Add(digest.MustNewDigest("A/x", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("A/x", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Build()).
 			Return(
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("A", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 					Add(digest.MustNewDigest("A/x", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 					Build(),
 				nil)
 		baseBlobAccessB.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("B", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("B", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Add(digest.MustNewDigest("B/x", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("B/x", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Build()).
 			Return(
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("B", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 					Add(digest.MustNewDigest("B/x", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 					Build(),
@@ -349,7 +349,7 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 
 		missing, err := blobAccess.FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Add(digest.MustNewDigest("a/x", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
@@ -362,7 +362,7 @@ func TestDemultiplexingBlobAccessFindMissing(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(
 			t,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("a/x", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).

--- a/pkg/blobstore/empty_blob_injecting_blob_access_test.go
+++ b/pkg/blobstore/empty_blob_injecting_blob_access_test.go
@@ -177,12 +177,12 @@ func TestEmptyBlobInjectingBlobAccessFindMissing(t *testing.T) {
 	baseBlobAccess := mock.NewMockBlobAccess(ctrl)
 	blobAccess := blobstore.NewEmptyBlobInjectingBlobAccess(baseBlobAccess)
 
-	unfilteredInputSet := digest.NewSetBuilder().
+	unfilteredInputSet := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "d41d8cd98f00b204e9800998ecf8427e", 0)).
 		Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 		Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 		Build()
-	filteredInputSet := digest.NewSetBuilder().
+	filteredInputSet := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 		Add(digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 		Build()

--- a/pkg/blobstore/existence_caching_blob_access_test.go
+++ b/pkg/blobstore/existence_caching_blob_access_test.go
@@ -24,7 +24,7 @@ func TestExistenceCachingBlobAccessFindMissing(t *testing.T) {
 		baseBlobAccess,
 		digest.NewExistenceCache(clock, digest.KeyWithoutInstance, 10, time.Minute, eviction.NewLRUSet[string]()))
 
-	bothDigests := digest.NewSetBuilder().
+	bothDigests := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_SHA256, "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969", 5)).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_SHA256, "78ae647dc5544d227130a0682a51e30bc7777fbb6d8a8f17007463a3ecd1d524", 5)).
 		Build()

--- a/pkg/blobstore/grpcclients/cas_blob_access.go
+++ b/pkg/blobstore/grpcclients/cas_blob_access.go
@@ -354,7 +354,7 @@ func findMissingBlobsInternal(ctx context.Context, digests digest.Set, cas remot
 		perFunctionDigests[digestFunction] = append(perFunctionDigests[digestFunction], digest.GetProto())
 	}
 
-	missingDigests := digest.NewSetBuilder()
+	missingDigests := digest.NewSetBuilder(0)
 	for digestFunction, blobDigests := range perFunctionDigests {
 		// Call FindMissingBlobs() for each digest function.
 		request := remoteexecution.FindMissingBlobsRequest{

--- a/pkg/blobstore/grpcclients/icas_blob_access.go
+++ b/pkg/blobstore/grpcclients/icas_blob_access.go
@@ -79,7 +79,7 @@ func (ba *icasBlobAccess) FindMissing(ctx context.Context, digests digest.Set) (
 		perFunctionDigests[digestFunction] = append(perFunctionDigests[digestFunction], digest.GetProto())
 	}
 
-	missingDigests := digest.NewSetBuilder()
+	missingDigests := digest.NewSetBuilder(0)
 	for digestFunction, blobDigests := range perFunctionDigests {
 		// Call FindMissingReferences() for each digest function.
 		request := remoteexecution.FindMissingBlobsRequest{

--- a/pkg/blobstore/grpcservers/content_addressable_storage_server.go
+++ b/pkg/blobstore/grpcservers/content_addressable_storage_server.go
@@ -40,7 +40,7 @@ func (s *contentAddressableStorageServer) FindMissingBlobs(ctx context.Context, 
 		return nil, err
 	}
 
-	inDigests := digest.NewSetBuilder()
+	inDigests := digest.NewSetBuilder(len(in.BlobDigests))
 	for _, partialDigest := range in.BlobDigests {
 		digest, err := digestFunction.NewDigestFromProto(partialDigest)
 		if err != nil {

--- a/pkg/blobstore/grpcservers/indirect_content_addressable_storage_server.go
+++ b/pkg/blobstore/grpcservers/indirect_content_addressable_storage_server.go
@@ -39,7 +39,7 @@ func (s *indirectContentAddressableStorageServer) FindMissingReferences(ctx cont
 		return nil, err
 	}
 
-	inDigests := digest.NewSetBuilder()
+	inDigests := digest.NewSetBuilder(len(in.BlobDigests))
 	for _, partialDigest := range in.BlobDigests {
 		digest, err := digestFunction.NewDigestFromProto(partialDigest)
 		if err != nil {

--- a/pkg/blobstore/grpcservers/indirect_content_addressable_storage_server_test.go
+++ b/pkg/blobstore/grpcservers/indirect_content_addressable_storage_server_test.go
@@ -43,7 +43,7 @@ func TestIndirectContentAddressableStorageServerFindMissingReferences(t *testing
 		// Errors returned by the backend should be forwarded.
 		blobAccess.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Build()).
@@ -69,7 +69,7 @@ func TestIndirectContentAddressableStorageServerFindMissingReferences(t *testing
 	t.Run("Success", func(t *testing.T) {
 		blobAccess.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7)).
 				Build()).

--- a/pkg/blobstore/hierarchical_instance_names_blob_access.go
+++ b/pkg/blobstore/hierarchical_instance_names_blob_access.go
@@ -74,7 +74,7 @@ func (ba *hierarchicalInstanceNamesBlobAccess) FindMissing(ctx context.Context, 
 		parentDigests  []digest.Digest
 	}
 	digestsWithParents := make([]digestWithParents, 0, len(initiallyMissingItems))
-	finallyMissing := digest.NewSetBuilder()
+	finallyMissing := digest.NewSetBuilder(0)
 	for _, originalDigest := range initiallyMissingItems {
 		if parentDigests := originalDigest.GetDigestsWithParentInstanceNames(); len(parentDigests) > 1 {
 			digestsWithParents = append(digestsWithParents, digestWithParents{
@@ -91,7 +91,7 @@ func (ba *hierarchicalInstanceNamesBlobAccess) FindMissing(ctx context.Context, 
 		// digests checked during the previous iteration.
 		// Convert the results to a set, so that we can
 		// efficiently check membership.
-		directParentDigests := digest.NewSetBuilder()
+		directParentDigests := digest.NewSetBuilder(len(digestsWithParents))
 		for _, digestWithParents := range digestsWithParents {
 			directParentDigests.Add(digestWithParents.parentDigests[len(digestWithParents.parentDigests)-1])
 		}

--- a/pkg/blobstore/hierarchical_instance_names_blob_access_test.go
+++ b/pkg/blobstore/hierarchical_instance_names_blob_access_test.go
@@ -135,7 +135,7 @@ func TestHierarchicalInstanceNamesBlobAccessFindMissing(t *testing.T) {
 	t.Run("InitialFailure", func(t *testing.T) {
 		// Errors that occur both during the initial call to
 		// FindMissing() and successive ones should be propagated.
-		digests := digest.NewSetBuilder().
+		digests := digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000001", 1)).
 			Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000002", 2)).
 			Add(digest.MustNewDigest("c", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000003", 3)).
@@ -148,20 +148,20 @@ func TestHierarchicalInstanceNamesBlobAccessFindMissing(t *testing.T) {
 	})
 
 	t.Run("SuccessiveFailure", func(t *testing.T) {
-		digests := digest.NewSetBuilder().
+		digests := digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000001", 1)).
 			Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000002", 2)).
 			Add(digest.MustNewDigest("c", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000003", 3)).
 			Build()
 		gomock.InOrder(
 			baseBlobAccess.EXPECT().FindMissing(ctx, digests).Return(
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000002", 2)).
 					Build(),
 				nil),
 			baseBlobAccess.EXPECT().FindMissing(
 				ctx,
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000002", 2)).
 					Build(),
 			).Return(digest.EmptySet, status.Error(codes.Internal, "Server on fire")))
@@ -181,7 +181,7 @@ func TestHierarchicalInstanceNamesBlobAccessFindMissing(t *testing.T) {
 		// requesting far more objects than necessary and will
 		// also cause objects to be touched, regardless of
 		// whether they are going to be accessed.
-		digests := digest.NewSetBuilder().
+		digests := digest.NewSetBuilder(0).
 			// Empty instance name.
 			Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000001", 1)).
 			Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000002", 2)).
@@ -198,7 +198,7 @@ func TestHierarchicalInstanceNamesBlobAccessFindMissing(t *testing.T) {
 			Build()
 		gomock.InOrder(
 			baseBlobAccess.EXPECT().FindMissing(ctx, digests).Return(
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000001", 1)).
 					Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "10000000000000000000000000000001", 3)).
 					Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "10000000000000000000000000000001", 3)).
@@ -208,20 +208,20 @@ func TestHierarchicalInstanceNamesBlobAccessFindMissing(t *testing.T) {
 				nil),
 			baseBlobAccess.EXPECT().FindMissing(
 				ctx,
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "10000000000000000000000000000001", 3)).
 					Add(digest.MustNewDigest("x", remoteexecution.DigestFunction_MD5, "30000000000000000000000000000001", 3)).
 					Build()).Return(
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("x", remoteexecution.DigestFunction_MD5, "30000000000000000000000000000001", 3)).
 					Build(),
 				nil),
 			baseBlobAccess.EXPECT().FindMissing(
 				ctx,
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "30000000000000000000000000000001", 3)).
 					Build()).Return(
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "30000000000000000000000000000001", 3)).
 					Build(),
 				nil))
@@ -230,7 +230,7 @@ func TestHierarchicalInstanceNamesBlobAccessFindMissing(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(
 			t,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000001", 1)).
 				Add(digest.MustNewDigest("x/y", remoteexecution.DigestFunction_MD5, "30000000000000000000000000000001", 3)).
 				Add(digest.MustNewDigest("x/z", remoteexecution.DigestFunction_MD5, "30000000000000000000000000000001", 3)).

--- a/pkg/blobstore/local/flat_blob_access.go
+++ b/pkg/blobstore/local/flat_blob_access.go
@@ -360,7 +360,7 @@ func (ba *flatBlobAccess) FindMissing(ctx context.Context, digests digest.Set) (
 		key    Key
 	}
 	var blobsToRefresh []blobToRefresh
-	missing := digest.NewSetBuilder()
+	missing := digest.NewSetBuilder(0)
 	ba.lock.RLock()
 	for i, blobDigest := range digests.Items() {
 		key := keys[i]

--- a/pkg/blobstore/local/hashing_key_location_map.go
+++ b/pkg/blobstore/local/hashing_key_location_map.go
@@ -47,6 +47,15 @@ var (
 			Help:      "Number of times Put() discarded an entry, because it took the maximum number of iterations, which may indicate the hash table is too small",
 		},
 		[]string{"storage_type"})
+
+	// errKeyLocationMapNotFound is returned by Get() for every key
+	// that is not present in the map. As Get() runs once per digest
+	// in FindMissing() and once per blob in Get(), constructing a
+	// fresh status object on every miss is one of the largest
+	// allocation sources on the FindMissingBlobs hot path. Callers
+	// only inspect the status code, never the message or instance
+	// identity, so a shared sentinel is safe.
+	errKeyLocationMapNotFound = status.Error(codes.NotFound, "Object not found")
 )
 
 type hashingKeyLocationMap struct {
@@ -134,7 +143,7 @@ func (klm *hashingKeyLocationMap) Get(key Key) (Location, error) {
 			// searching, as everything we find after this
 			// point is even older.
 			klm.getNotFound.Observe(float64(recordKey.Attempt + 1))
-			return Location{}, status.Error(codes.NotFound, "Object not found")
+			return Location{}, errKeyLocationMapNotFound
 		} else if err != nil {
 			return Location{}, err
 		}
@@ -145,7 +154,7 @@ func (klm *hashingKeyLocationMap) Get(key Key) (Location, error) {
 		recordKey.Attempt++
 		if recordKey.Attempt >= klm.maximumGetAttempts {
 			klm.getTooManyAttempts.Inc()
-			return Location{}, status.Error(codes.NotFound, "Object not found")
+			return Location{}, errKeyLocationMapNotFound
 		}
 	}
 }

--- a/pkg/blobstore/local/hierarchical_cas_blob_access.go
+++ b/pkg/blobstore/local/hierarchical_cas_blob_access.go
@@ -93,7 +93,7 @@ func (ba *hierarchicalCASBlobAccess) getLeastSpecificLookupEntry(lookupKeys []Ke
 			return Key{}, Location{}, err
 		}
 	}
-	return Key{}, Location{}, status.Error(codes.NotFound, "Object not found")
+	return Key{}, Location{}, errKeyLocationMapNotFound
 }
 
 // syncFromCanonicalEntry attempts to synchronize a lookup entry in the

--- a/pkg/blobstore/local/hierarchical_cas_blob_access.go
+++ b/pkg/blobstore/local/hierarchical_cas_blob_access.go
@@ -303,7 +303,7 @@ func (ba *hierarchicalCASBlobAccess) FindMissing(ctx context.Context, digests di
 		lookupKeys []Key
 	}
 	var blobsToRefresh []blobToRefresh
-	missing := digest.NewSetBuilder()
+	missing := digest.NewSetBuilder(0)
 	ba.lock.RLock()
 	for i, blobDigest := range digests.Items() {
 		lookupKeys := allLookupKeys[i]

--- a/pkg/blobstore/mirrored/mirrored_blob_access_test.go
+++ b/pkg/blobstore/mirrored/mirrored_blob_access_test.go
@@ -190,11 +190,11 @@ func TestMirroredBlobAccessFindMissing(t *testing.T) {
 	digestA := digest.MustNewDigest("default", remoteexecution.DigestFunction_SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", 0)
 	digestB := digest.MustNewDigest("default", remoteexecution.DigestFunction_SHA256, "522b44d647b6989f60302ef755c277e508d5bcc38f05e139906ebdb03a5b19f2", 9)
 	digestBoth := digest.MustNewDigest("default", remoteexecution.DigestFunction_SHA256, "9c6079651d4062b6811f93061cb6a768a60e51d714bddffee99b1173c6580580", 5)
-	allDigests := digest.NewSetBuilder().Add(digestNone).Add(digestA).Add(digestB).Add(digestBoth).Build()
+	allDigests := digest.NewSetBuilder(0).Add(digestNone).Add(digestA).Add(digestB).Add(digestBoth).Build()
 	onlyOnA := digestA.ToSingletonSet()
 	onlyOnB := digestB.ToSingletonSet()
-	missingFromA := digest.NewSetBuilder().Add(digestNone).Add(digestB).Build()
-	missingFromB := digest.NewSetBuilder().Add(digestNone).Add(digestA).Build()
+	missingFromA := digest.NewSetBuilder(0).Add(digestNone).Add(digestB).Build()
+	missingFromB := digest.NewSetBuilder(0).Add(digestNone).Add(digestA).Build()
 	blobAccess := mirrored.NewMirroredBlobAccess(backendA, backendB, replicatorAToB, replicatorBToA)
 
 	t.Run("Success", func(t *testing.T) {

--- a/pkg/blobstore/read_canarying_blob_access_test.go
+++ b/pkg/blobstore/read_canarying_blob_access_test.go
@@ -172,7 +172,7 @@ func TestReadCanaryingBlobAccess(t *testing.T) {
 		clock.EXPECT().Now().Return(time.Unix(20001, 0))
 		replicaBackend.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("find-missing/1", remoteexecution.DigestFunction_MD5, "11111111111111111111111111111111", 1)).
 				Add(digest.MustNewDigest("find-missing/1", remoteexecution.DigestFunction_MD5, "22222222222222222222222222222222", 2)).
 				Build(),
@@ -180,7 +180,7 @@ func TestReadCanaryingBlobAccess(t *testing.T) {
 		clock.EXPECT().Now().Return(time.Unix(20001, 100000000)).Times(2)
 		replicaBackend.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("find-missing/2", remoteexecution.DigestFunction_MD5, "33333333333333333333333333333333", 3)).
 				Add(digest.MustNewDigest("find-missing/2", remoteexecution.DigestFunction_MD5, "44444444444444444444444444444444", 4)).
 				Build(),
@@ -188,7 +188,7 @@ func TestReadCanaryingBlobAccess(t *testing.T) {
 		clock.EXPECT().Now().Return(time.Unix(20001, 100000000)).Times(2)
 		sourceBackend.EXPECT().FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("find-missing/down", remoteexecution.DigestFunction_MD5, "55555555555555555555555555555555", 5)).
 				Add(digest.MustNewDigest("find-missing/down", remoteexecution.DigestFunction_MD5, "66666666666666666666666666666666", 6)).
 				Build(),
@@ -196,7 +196,7 @@ func TestReadCanaryingBlobAccess(t *testing.T) {
 
 		missing, err = blobAccess.FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("find-missing/1", remoteexecution.DigestFunction_MD5, "11111111111111111111111111111111", 1)).
 				Add(digest.MustNewDigest("find-missing/1", remoteexecution.DigestFunction_MD5, "22222222222222222222222222222222", 2)).
 				Add(digest.MustNewDigest("find-missing/2", remoteexecution.DigestFunction_MD5, "33333333333333333333333333333333", 3)).
@@ -207,7 +207,7 @@ func TestReadCanaryingBlobAccess(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(
 			t,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("find-missing/1", remoteexecution.DigestFunction_MD5, "11111111111111111111111111111111", 1)).
 				Add(digest.MustNewDigest("find-missing/2", remoteexecution.DigestFunction_MD5, "33333333333333333333333333333333", 3)).
 				Add(digest.MustNewDigest("find-missing/down", remoteexecution.DigestFunction_MD5, "55555555555555555555555555555555", 5)).

--- a/pkg/blobstore/readcaching/read_caching_blob_access_test.go
+++ b/pkg/blobstore/readcaching/read_caching_blob_access_test.go
@@ -117,7 +117,7 @@ func TestReadCachingBlobAccessFindMissing(t *testing.T) {
 	fastBlobAccess := mock.NewMockBlobAccess(ctrl)
 	blobReplicator := mock.NewMockBlobReplicator(ctrl)
 	blobAccess := readcaching.NewReadCachingBlobAccess(slowBlobAccess, fastBlobAccess, blobReplicator)
-	digests := digest.NewSetBuilder().
+	digests := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("default", remoteexecution.DigestFunction_SHA256, "64ec88ca00b268e5ba1a35678a1b5316d212f4f366b2477232534a8aeca37f3c", 11)).
 		Add(digest.MustNewDigest("default", remoteexecution.DigestFunction_SHA256, "82e35a63ceba37e9646434c5dd412ea577147f1e4a41ccde1614253187e3dbf9", 7)).
 		Build()

--- a/pkg/blobstore/readfallback/read_fallback_blob_access_test.go
+++ b/pkg/blobstore/readfallback/read_fallback_blob_access_test.go
@@ -163,12 +163,12 @@ func TestReadFallbackBlobAccessFindMissing(t *testing.T) {
 	replicator := mock.NewMockBlobReplicator(ctrl)
 	blobAccess := readfallback.NewReadFallbackBlobAccess(primary, secondary, replicator)
 
-	allDigests := digest.NewSetBuilder().
+	allDigests := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000000", 100)).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000001", 101)).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000002", 102)).
 		Build()
-	missingFromPrimary := digest.NewSetBuilder().
+	missingFromPrimary := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000000", 100)).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "00000000000000000000000000000001", 101)).
 		Build()

--- a/pkg/blobstore/reference_expanding_blob_access_test.go
+++ b/pkg/blobstore/reference_expanding_blob_access_test.go
@@ -534,7 +534,7 @@ func TestReferenceExpandingBlobAccessFindMissing(t *testing.T) {
 		100,
 		bb_zstd.NewUnboundedPool(nil, []zstd.DOption{zstd.WithDecoderConcurrency(1)}))
 
-	digests := digest.NewSetBuilder().
+	digests := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "f5a7924e621e84c9280a9a27e1bcb7f6", 5)).
 		Build()

--- a/pkg/blobstore/replication/deduplicating_blob_replicator_test.go
+++ b/pkg/blobstore/replication/deduplicating_blob_replicator_test.go
@@ -186,7 +186,7 @@ func TestDeduplicatingBlobReplicatorReplicateMultiple(t *testing.T) {
 	helloDigestSet := helloDigest.ToSingletonSet()
 	worldDigest := digest.MustNewDigest("world", remoteexecution.DigestFunction_MD5, "f5a7924e621e84c9280a9a27e1bcb7f6", 5)
 	worldDigestSet := worldDigest.ToSingletonSet()
-	allDigests := digest.NewSetBuilder().Add(helloDigest).Add(worldDigest).Build()
+	allDigests := digest.NewSetBuilder(0).Add(helloDigest).Add(worldDigest).Build()
 
 	// Only a single test for the success case is provided, as the
 	// tests for ReplicateSingle() provide enough coverage.

--- a/pkg/blobstore/replication/local_blob_replicator_test.go
+++ b/pkg/blobstore/replication/local_blob_replicator_test.go
@@ -115,7 +115,7 @@ func TestLocalBlobReplicatorReplicateMultiple(t *testing.T) {
 			t,
 			replicator.ReplicateMultiple(
 				ctx,
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(helloDigest).
 					Add(worldDigest).
 					Build()))

--- a/pkg/blobstore/replication/metrics_blob_replicator_test.go
+++ b/pkg/blobstore/replication/metrics_blob_replicator_test.go
@@ -63,7 +63,7 @@ func TestMetricsBlobReplicatorLabelCardinality(t *testing.T) {
 	b.Discard()
 
 	// Test ReplicateMultiple
-	digests := digest.NewSetBuilder().Add(d).Build()
+	digests := digest.NewSetBuilder(0).Add(d).Build()
 	mockReplicator.EXPECT().
 		ReplicateMultiple(gomock.Any(), digests).
 		Return(status.Error(codes.Internal, "internal error"))

--- a/pkg/blobstore/replication/nested_blob_replicator.go
+++ b/pkg/blobstore/replication/nested_blob_replicator.go
@@ -117,7 +117,7 @@ func (nr *NestedBlobReplicator) EnqueueDirectory(directoryDigest digest.Digest) 
 			nr.EnqueueDirectory(childDigest)
 		}
 
-		childFileDigests := digest.NewSetBuilder()
+		childFileDigests := digest.NewSetBuilder(len(directory.Files))
 		for i, childFile := range directory.Files {
 			childFileDigest, err := digestFunction.NewDigestFromProto(childFile.Digest)
 			if err != nil {
@@ -141,7 +141,7 @@ func (nr *NestedBlobReplicator) EnqueueTree(treeDigest digest.Digest) {
 		defer r.Close()
 
 		// Gather digests of files contained in the directories.
-		childFileDigests := digest.NewSetBuilder()
+		childFileDigests := digest.NewSetBuilder(0)
 		if err := util.VisitProtoBytesFields(r, func(fieldNumber protowire.Number, offsetBytes, sizeBytes int64, fieldReader io.Reader) error {
 			if fieldNumber == blobstore.TreeRootFieldNumber || fieldNumber == blobstore.TreeChildrenFieldNumber {
 				directoryMessage, err := buffer.NewProtoBufferFromReader(

--- a/pkg/blobstore/replication/nested_blob_replicator_test.go
+++ b/pkg/blobstore/replication/nested_blob_replicator_test.go
@@ -139,7 +139,7 @@ func TestNestedBlobReplicator(t *testing.T) {
 			Return(buffer.NewProtoBufferFromProto(&remoteexecution.Directory{}, buffer.UserProvided))
 		replicator.EXPECT().ReplicateMultiple(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "6f881c3ef7c841fa5fe3f9e35fd8a745", 7)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "211aa29e2a010eae1bb65b3eed479d6c", 8)).
 				Build())
@@ -147,7 +147,7 @@ func TestNestedBlobReplicator(t *testing.T) {
 			Return(buffer.NewProtoBufferFromProto(&remoteexecution.Directory{}, buffer.UserProvided))
 		replicator.EXPECT().ReplicateMultiple(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "66b39b7d2658407275b6a55ef403f3d0", 10)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "13d059e4e8609ea76009df43ff5157d6", 12)).
 				Build())

--- a/pkg/blobstore/replication/replicator_server.go
+++ b/pkg/blobstore/replication/replicator_server.go
@@ -32,7 +32,7 @@ func (rs replicatorServer) ReplicateBlobs(ctx context.Context, request *replicat
 		return nil, err
 	}
 
-	digests := digest.NewSetBuilder()
+	digests := digest.NewSetBuilder(len(request.BlobDigests))
 	for i, blobDigest := range request.BlobDigests {
 		d, err := digestFunction.NewDigestFromProto(blobDigest)
 		if err != nil {

--- a/pkg/blobstore/sharding/sharding_blob_access.go
+++ b/pkg/blobstore/sharding/sharding_blob_access.go
@@ -71,7 +71,7 @@ func (ba *shardingBlobAccess) FindMissing(ctx context.Context, digests digest.Se
 	// Partition all digests by shard.
 	digestsPerBackend := make([]digest.SetBuilder, 0, len(ba.backends))
 	for range ba.backends {
-		digestsPerBackend = append(digestsPerBackend, digest.NewSetBuilder())
+		digestsPerBackend = append(digestsPerBackend, digest.NewSetBuilder(digests.Length()/len(ba.backends)+1))
 	}
 	for _, blobDigest := range digests.Items() {
 		digestsPerBackend[ba.getBackendIndexByDigest(blobDigest)].Add(blobDigest)

--- a/pkg/blobstore/sharding/sharding_blob_access_test.go
+++ b/pkg/blobstore/sharding/sharding_blob_access_test.go
@@ -132,7 +132,7 @@ func TestShardingBlobAccess(t *testing.T) {
 
 		_, err := blobAccess.FindMissing(
 			ctx,
-			digest.NewSetBuilder().Add(digest1).Add(digest2).Build(),
+			digest.NewSetBuilder(0).Add(digest1).Add(digest2).Build(),
 		)
 		testutil.RequireEqualStatus(t, status.Error(codes.Unavailable, "Shard shard0: Server offline"), err)
 	})
@@ -144,21 +144,21 @@ func TestShardingBlobAccess(t *testing.T) {
 		shardSelector.EXPECT().GetShard(uint64(0xf8f3da00ff286208)).Return(1)
 		shard0.EXPECT().FindMissing(
 			gomock.Any(),
-			digest.NewSetBuilder().Add(digest1).Add(digest2).Build(),
+			digest.NewSetBuilder(0).Add(digest1).Add(digest2).Build(),
 		).Return(digest1.ToSingletonSet(), nil)
 		shard1.EXPECT().FindMissing(
 			gomock.Any(),
-			digest.NewSetBuilder().Add(digest3).Add(digest4).Build(),
+			digest.NewSetBuilder(0).Add(digest3).Add(digest4).Build(),
 		).Return(digest3.ToSingletonSet(), nil)
 
 		missing, err := blobAccess.FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest1).Add(digest2).
 				Add(digest3).Add(digest4).
 				Build(),
 		)
 		require.NoError(t, err)
-		require.Equal(t, digest.NewSetBuilder().Add(digest1).Add(digest3).Build(), missing)
+		require.Equal(t, digest.NewSetBuilder(0).Add(digest1).Add(digest3).Build(), missing)
 	})
 }

--- a/pkg/blobstore/zip_reading_blob_access.go
+++ b/pkg/blobstore/zip_reading_blob_access.go
@@ -84,7 +84,7 @@ func (zipReadingBlobAccess) Put(ctx context.Context, digest digest.Digest, b buf
 }
 
 func (ba *zipReadingBlobAccess) FindMissing(ctx context.Context, digests digest.Set) (digest.Set, error) {
-	missing := digest.NewSetBuilder()
+	missing := digest.NewSetBuilder(0)
 	for _, fileDigest := range digests.Items() {
 		if _, ok := ba.files[fileDigest.GetKey(ba.digestKeyFormat)]; !ok {
 			missing.Add(fileDigest)

--- a/pkg/blobstore/zip_reading_blob_access_test.go
+++ b/pkg/blobstore/zip_reading_blob_access_test.go
@@ -153,7 +153,7 @@ func TestZIPReadingBlobAccess(t *testing.T) {
 	t.Run("FindMissing", func(t *testing.T) {
 		missing, err := blobAccess.FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "8b1a9953c4611296a827abf8c47804d7", 5)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_SHA1, "897256b6709e1a4da9daba92b6bde39ccfccd8c1", 16384)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_SHA256, "522b44d647b6989f60302ef755c277e508d5bcc38f05e139906ebdb03a5b19f2", 9)).

--- a/pkg/blobstore/zip_writing_blob_access.go
+++ b/pkg/blobstore/zip_writing_blob_access.go
@@ -207,7 +207,7 @@ func (ba *ZIPWritingBlobAccess) FindMissing(ctx context.Context, digests digest.
 	ba.lock.Lock()
 	defer ba.lock.Unlock()
 
-	missing := digest.NewSetBuilder()
+	missing := digest.NewSetBuilder(0)
 	for _, fileDigest := range digests.Items() {
 		if _, ok := ba.filesAccess[fileDigest.GetKey(ba.digestKeyFormat)]; !ok {
 			missing.Add(fileDigest)

--- a/pkg/blobstore/zip_writing_blob_access_test.go
+++ b/pkg/blobstore/zip_writing_blob_access_test.go
@@ -187,7 +187,7 @@ func TestZIPWritingBlobAccess(t *testing.T) {
 	t.Run("FindMissing", func(t *testing.T) {
 		missing, err := blobAccess.FindMissing(
 			ctx,
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_SHA256, "185f8db32271fe25f561a6fc938b2e264306ec304eda518007d1764826381969", 5)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "ebbbb099e9d2f7892d97ab3640ae8283", 9)).
 				Add(digest.MustNewDigest("example", remoteexecution.DigestFunction_MD5, "5479092d62cdb7c8e8eedef4a5eb2164", 720)).

--- a/pkg/digest/digest_test.go
+++ b/pkg/digest/digest_test.go
@@ -545,7 +545,7 @@ func TestDigestToSingletonSet(t *testing.T) {
 	d := digest.MustNewDigest("hello", remoteexecution.DigestFunction_SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", 123)
 	require.Equal(
 		t,
-		digest.NewSetBuilder().Add(d).Build(),
+		digest.NewSetBuilder(0).Add(d).Build(),
 		d.ToSingletonSet())
 }
 

--- a/pkg/digest/digest_test.go
+++ b/pkg/digest/digest_test.go
@@ -1,6 +1,7 @@
 package digest_test
 
 import (
+	"math"
 	"testing"
 
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
@@ -526,6 +527,45 @@ func TestDigestGetKey(t *testing.T) {
 		require.Equal(
 			t,
 			"8-5d8242df5726318bec51ccc6166a284ce40850cb7e9f4b041ce3df8a7fa61dc4-123-hello",
+			d.GetKey(digest.KeyWithInstance))
+	})
+
+	// Edge cases for the size and instance name components, which
+	// exercise the boundaries of the digest string encoding in
+	// Function.newDigestUnchecked().
+	t.Run("ZeroSize", func(t *testing.T) {
+		d := digest.MustNewDigest("hello", remoteexecution.DigestFunction_SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", 0)
+		require.Equal(
+			t,
+			"1-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-0",
+			d.GetKey(digest.KeyWithoutInstance))
+		require.Equal(
+			t,
+			"1-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-0-hello",
+			d.GetKey(digest.KeyWithInstance))
+	})
+
+	t.Run("MaximumSize", func(t *testing.T) {
+		d := digest.MustNewDigest("hello", remoteexecution.DigestFunction_SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", math.MaxInt64)
+		require.Equal(
+			t,
+			"1-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-9223372036854775807",
+			d.GetKey(digest.KeyWithoutInstance))
+		require.Equal(
+			t,
+			"1-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-9223372036854775807-hello",
+			d.GetKey(digest.KeyWithInstance))
+	})
+
+	t.Run("EmptyInstanceName", func(t *testing.T) {
+		d := digest.MustNewDigest("", remoteexecution.DigestFunction_SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", 123)
+		require.Equal(
+			t,
+			"1-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-123",
+			d.GetKey(digest.KeyWithoutInstance))
+		require.Equal(
+			t,
+			"1-e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-123-",
 			d.GetKey(digest.KeyWithInstance))
 	})
 }

--- a/pkg/digest/existence_cache.go
+++ b/pkg/digest/existence_cache.go
@@ -43,7 +43,7 @@ func NewExistenceCache(clock clock.Clock, keyFormat KeyFormat, cacheSize int, ca
 func (ec *ExistenceCache) RemoveExisting(digests Set) Set {
 	now := ec.clock.Now()
 	minimumInsertionTime := now.Add(-ec.cacheDuration)
-	missing := NewSetBuilder()
+	missing := NewSetBuilder(0)
 	ec.lock.Lock()
 	for _, d := range digests.Items() {
 		key := d.GetKey(ec.keyFormat)

--- a/pkg/digest/existence_cache_test.go
+++ b/pkg/digest/existence_cache_test.go
@@ -24,7 +24,7 @@ func TestExistenceCache(t *testing.T) {
 		digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "6fc422233a40a75a1f028e11c3cd1140", 7),
 		digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "ebbbb099e9d2f7892d97ab3640ae8283", 9),
 	}
-	allDigests := digest.NewSetBuilder().
+	allDigests := digest.NewSetBuilder(0).
 		Add(digests[0]).
 		Add(digests[1]).
 		Add(digests[2]).
@@ -49,7 +49,7 @@ func TestExistenceCache(t *testing.T) {
 	// Mark the first two elements as existing. RemoveExisting()
 	// should now start pruning them from the input set.
 	clock.EXPECT().Now().Return(time.Unix(1003, 0))
-	existenceCache.Add(digest.NewSetBuilder().
+	existenceCache.Add(digest.NewSetBuilder(0).
 		Add(digests[0]).
 		Add(digests[1]).
 		Build())
@@ -65,11 +65,11 @@ func TestExistenceCache(t *testing.T) {
 	require.Equal(
 		t,
 		digest.EmptySet,
-		existenceCache.RemoveExisting(digest.NewSetBuilder().
+		existenceCache.RemoveExisting(digest.NewSetBuilder(0).
 			Add(digests[1]).
 			Build()))
 	clock.EXPECT().Now().Return(time.Unix(1006, 0))
-	existenceCache.Add(digest.NewSetBuilder().
+	existenceCache.Add(digest.NewSetBuilder(0).
 		Add(digests[2]).
 		Build())
 	clock.EXPECT().Now().Return(time.Unix(1007, 0))
@@ -83,14 +83,14 @@ func TestExistenceCache(t *testing.T) {
 	clock.EXPECT().Now().Return(time.Unix(1063, 0))
 	require.Equal(
 		t,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digests[0]).
 			Build(),
 		existenceCache.RemoveExisting(allDigests))
 	clock.EXPECT().Now().Return(time.Unix(1063, 1))
 	require.Equal(
 		t,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digests[0]).
 			Add(digests[1]).
 			Build(),
@@ -101,7 +101,7 @@ func TestExistenceCache(t *testing.T) {
 	clock.EXPECT().Now().Return(time.Unix(1066, 0))
 	require.Equal(
 		t,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digests[0]).
 			Add(digests[1]).
 			Build(),

--- a/pkg/digest/function.go
+++ b/pkg/digest/function.go
@@ -2,8 +2,8 @@ package digest
 
 import (
 	"encoding/hex"
-	"fmt"
 	"hash"
+	"strconv"
 
 	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 
@@ -85,10 +85,25 @@ func (f Function) NewDigest(hash string, sizeBytes int64) (Digest, error) {
 
 // newDigestUnchecked constructs a Digest object from a digest function,
 // hash and object size without validating its contents.
+//
+// This function is on the hot path of every digest constructed from a
+// proto (FindMissingBlobs, BatchReadBlobs, BatchUpdateBlobs, ActionCache
+// lookups, ByteStream path parsing). It is implemented with a single
+// pre-sized []byte builder rather than fmt.Sprintf to avoid argument
+// boxing, format-string parsing and reflection.
 func (f Function) newDigestUnchecked(hash string, sizeBytes int64) Digest {
-	return Digest{
-		value: fmt.Sprintf("%d-%s-%d-%s", int(f.bareFunction.enumValue), hash, sizeBytes, f.instanceName.value),
-	}
+	// Buffer is sized to fit the worst case: a two-digit digest
+	// function enum, the hash, a 19-digit int64 size, the instance
+	// name and three '-' separators.
+	buf := make([]byte, 0, 2+1+len(hash)+1+19+1+len(f.instanceName.value))
+	buf = strconv.AppendInt(buf, int64(f.bareFunction.enumValue), 10)
+	buf = append(buf, '-')
+	buf = append(buf, hash...)
+	buf = append(buf, '-')
+	buf = strconv.AppendInt(buf, sizeBytes, 10)
+	buf = append(buf, '-')
+	buf = append(buf, f.instanceName.value...)
+	return Digest{value: string(buf)}
 }
 
 // NewDigestFromProto constructs a Digest object from a digest function

--- a/pkg/digest/set_builder.go
+++ b/pkg/digest/set_builder.go
@@ -1,7 +1,8 @@
 package digest
 
 import (
-	"sort"
+	"slices"
+	"strings"
 )
 
 // SetBuilder is a builder for Set objects.
@@ -9,10 +10,15 @@ type SetBuilder struct {
 	digests map[Digest]struct{}
 }
 
-// NewSetBuilder creates a SetBuilder that contains no initial elements.
-func NewSetBuilder() SetBuilder {
+// NewSetBuilder creates a SetBuilder that contains no initial
+// elements. The capacity argument pre-sizes the underlying map so that
+// adding up to that many elements does not require rehashing. Callers
+// should provide a sensible estimate based on the context in which the
+// set is built (e.g., the number of digests in an incoming request).
+// Pass zero when no estimate is available.
+func NewSetBuilder(capacity int) SetBuilder {
 	return SetBuilder{
-		digests: map[Digest]struct{}{},
+		digests: make(map[Digest]struct{}, capacity),
 	}
 }
 
@@ -37,29 +43,17 @@ func (sb SetBuilder) Build() Set {
 	}
 
 	// Store all digests in a list.
-	digests := make(digestList, 0, len(sb.digests))
+	digests := make([]Digest, 0, len(sb.digests))
 	for digest := range sb.digests {
 		digests = append(digests, digest)
 	}
 
 	// Sort the list for determinism and to allow linear time
 	// implementations of GetDifferenceAndIntersection() and
-	// GetUnion().
-	sort.Sort(digests)
+	// GetUnion(). slices.SortFunc avoids the per-comparison
+	// interface dispatch of sort.Sort.
+	slices.SortFunc(digests, func(a, b Digest) int {
+		return strings.Compare(a.value, b.value)
+	})
 	return Set{digests: digests}
-}
-
-// digestList implements a list of digests that is sortable.
-type digestList []Digest
-
-func (l digestList) Len() int {
-	return len(l)
-}
-
-func (l digestList) Less(i, j int) bool {
-	return l[i].String() < l[j].String()
-}
-
-func (l digestList) Swap(i, j int) {
-	l[i], l[j] = l[j], l[i]
 }

--- a/pkg/digest/set_builder_test.go
+++ b/pkg/digest/set_builder_test.go
@@ -3,6 +3,7 @@ package digest_test
 import (
 	"testing"
 
+	remoteexecution "github.com/bazelbuild/remote-apis/build/bazel/remote/execution/v2"
 	"github.com/buildbarn/bb-storage/pkg/digest"
 	"github.com/stretchr/testify/require"
 )
@@ -17,4 +18,54 @@ func TestSetBuilderEmpty(t *testing.T) {
 	// sets. Letting those use an additional allocation would be
 	// wasteful.
 	require.Equal(t, digest.EmptySet, digest.NewSetBuilder(0).Build())
+}
+
+func TestSetBuilderCapacity(t *testing.T) {
+	// The capacity argument is purely a sizing optimization. The
+	// resulting Set must be indistinguishable regardless of the
+	// capacity hint, including the EmptySet invariant when no
+	// elements are added.
+	t.Run("Empty", func(t *testing.T) {
+		require.Equal(t, digest.EmptySet, digest.NewSetBuilder(0).Build())
+		require.Equal(t, digest.EmptySet, digest.NewSetBuilder(100).Build())
+	})
+
+	t.Run("Equivalence", func(t *testing.T) {
+		digests := []digest.Digest{
+			digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "cccccccccccccccccccccccccccccccc", 3),
+			digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1),
+			digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 2),
+		}
+		expected := digest.NewSetBuilder(0)
+		actual := digest.NewSetBuilder(len(digests))
+		for _, d := range digests {
+			expected.Add(d)
+			actual.Add(d)
+		}
+		require.Equal(t, expected.Build(), actual.Build())
+	})
+}
+
+func TestSetBuilderOrdering(t *testing.T) {
+	// Build() must return digests in a stable, sorted order
+	// regardless of insertion order, so that Set comparison
+	// operations such as GetDifferenceAndIntersection() and
+	// GetUnion() can be implemented in linear time.
+	d1 := digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1)
+	d2 := digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 2)
+	d3 := digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "cccccccccccccccccccccccccccccccc", 3)
+	d4 := digest.MustNewDigest("hello", remoteexecution.DigestFunction_MD5, "dddddddddddddddddddddddddddddddd", 4)
+	want := []digest.Digest{d1, d2, d3, d4}
+
+	t.Run("ReverseOrder", func(t *testing.T) {
+		require.Equal(t, want, digest.NewSetBuilder(0).Add(d4).Add(d3).Add(d2).Add(d1).Build().Items())
+	})
+
+	t.Run("ShuffledOrder", func(t *testing.T) {
+		require.Equal(t, want, digest.NewSetBuilder(0).Add(d2).Add(d4).Add(d1).Add(d3).Build().Items())
+	})
+
+	t.Run("Duplicates", func(t *testing.T) {
+		require.Equal(t, want, digest.NewSetBuilder(0).Add(d3).Add(d1).Add(d3).Add(d2).Add(d4).Add(d1).Build().Items())
+	})
 }

--- a/pkg/digest/set_builder_test.go
+++ b/pkg/digest/set_builder_test.go
@@ -16,5 +16,5 @@ func TestSetBuilderEmpty(t *testing.T) {
 	// fairly common for BlobAccess.FindMissing() to return empty
 	// sets. Letting those use an additional allocation would be
 	// wasteful.
-	require.Equal(t, digest.EmptySet, digest.NewSetBuilder().Build())
+	require.Equal(t, digest.EmptySet, digest.NewSetBuilder(0).Build())
 }

--- a/pkg/digest/set_test.go
+++ b/pkg/digest/set_test.go
@@ -12,7 +12,7 @@ func TestSetEmpty(t *testing.T) {
 	require.True(t, digest.EmptySet.Empty())
 	require.False(
 		t,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 123)).
 			Build().Empty())
 }
@@ -21,7 +21,7 @@ func TestSetFirst(t *testing.T) {
 	_, ok := digest.EmptySet.First()
 	require.False(t, ok)
 
-	d, ok := digest.NewSetBuilder().
+	d, ok := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 123)).
 		Build().First()
 	require.True(t, ok)
@@ -33,13 +33,13 @@ func TestSetLength(t *testing.T) {
 	require.Equal(
 		t,
 		1,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 123)).
 			Build().Length())
 	require.Equal(
 		t,
 		2,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 123)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 123)).
 			Build().Length())
@@ -52,7 +52,7 @@ func TestSetRemoveEmptyBlob(t *testing.T) {
 	require.Equal(
 		t,
 		digest.EmptySet,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "d41d8cd98f00b204e9800998ecf8427e", 0)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_SHA1, "da39a3ee5e6b4b0d3255bfef95601890afd80709", 0)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_SHA256, "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855", 0)).
@@ -62,11 +62,11 @@ func TestSetRemoveEmptyBlob(t *testing.T) {
 	// Set consisting entirely of non-empty blobs.
 	require.Equal(
 		t,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "3e25960a79dbc69b674cd4ec67a72c62", 11)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "d80d8a581e9e2b78fd2f5d990d0f0e21", 13)).
 			Build(),
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "3e25960a79dbc69b674cd4ec67a72c62", 11)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "d80d8a581e9e2b78fd2f5d990d0f0e21", 13)).
 			Build().
@@ -75,11 +75,11 @@ func TestSetRemoveEmptyBlob(t *testing.T) {
 	// Set consisting of both empty and non-empty blobs.
 	require.Equal(
 		t,
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "3e25960a79dbc69b674cd4ec67a72c62", 11)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "d80d8a581e9e2b78fd2f5d990d0f0e21", 13)).
 			Build(),
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "d41d8cd98f00b204e9800998ecf8427e", 0)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "3e25960a79dbc69b674cd4ec67a72c62", 11)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "d80d8a581e9e2b78fd2f5d990d0f0e21", 13)).
@@ -90,7 +90,7 @@ func TestSetRemoveEmptyBlob(t *testing.T) {
 func TestPartitionByInstanceName(t *testing.T) {
 	require.Empty(t, digest.EmptySet.PartitionByInstanceName())
 
-	singleInstanceName := digest.NewSetBuilder().
+	singleInstanceName := digest.NewSetBuilder(0).
 		Add(digest.MustNewDigest("foo", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1)).
 		Add(digest.MustNewDigest("foo", remoteexecution.DigestFunction_MD5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 2)).
 		Add(digest.MustNewDigest("foo", remoteexecution.DigestFunction_MD5, "cccccccccccccccccccccccccccccccc", 3)).
@@ -100,24 +100,24 @@ func TestPartitionByInstanceName(t *testing.T) {
 
 	require.Equal(
 		t, []digest.Set{
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "11111111111111111111111111111111", 1)).
 				Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "22222222222222222222222222222222", 2)).
 				Build(),
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "33333333333333333333333333333333", 3)).
 				Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "44444444444444444444444444444444", 4)).
 				Build(),
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("c", remoteexecution.DigestFunction_MD5, "55555555555555555555555555555555", 5)).
 				Add(digest.MustNewDigest("c", remoteexecution.DigestFunction_MD5, "66666666666666666666666666666666", 6)).
 				Build(),
-			digest.NewSetBuilder().
+			digest.NewSetBuilder(0).
 				Add(digest.MustNewDigest("d", remoteexecution.DigestFunction_MD5, "77777777777777777777777777777777", 7)).
 				Add(digest.MustNewDigest("d", remoteexecution.DigestFunction_MD5, "88888888888888888888888888888888", 8)).
 				Build(),
 		},
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "11111111111111111111111111111111", 1)).
 			Add(digest.MustNewDigest("a", remoteexecution.DigestFunction_MD5, "22222222222222222222222222222222", 2)).
 			Add(digest.MustNewDigest("b", remoteexecution.DigestFunction_MD5, "33333333333333333333333333333333", 3)).
@@ -132,13 +132,13 @@ func TestPartitionByInstanceName(t *testing.T) {
 
 func TestGetDifferenceAndIntersection(t *testing.T) {
 	onlyA, both, onlyB := digest.GetDifferenceAndIntersection(
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "0aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 123)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "1aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 123)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "0fffffffffffffffffffffffffffffff", 789)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "1fffffffffffffffffffffffffffffff", 789)).
 			Build(),
-		digest.NewSetBuilder().
+		digest.NewSetBuilder(0).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "0bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 456)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "1bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 456)).
 			Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "0fffffffffffffffffffffffffffffff", 789)).
@@ -185,7 +185,7 @@ func TestGetUnion(t *testing.T) {
 				digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 1),
 			},
 			digest.GetUnion([]digest.Set{
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 1)).
 					Build(),
@@ -206,19 +206,19 @@ func TestGetUnion(t *testing.T) {
 				digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "cccccccccccccccccccccccccccccccc", 1),
 			},
 			digest.GetUnion([]digest.Set{
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "abababababababababababababababab", 2)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "acacacacacacacacacacacacacacacac", 2)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "abcabcabcabcabcabcabcabcabcabcab", 3)).
 					Build(),
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", 1)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "abababababababababababababababab", 2)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "bcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbc", 2)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "abcabcabcabcabcabcabcabcabcabcab", 3)).
 					Build(),
-				digest.NewSetBuilder().
+				digest.NewSetBuilder(0).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "cccccccccccccccccccccccccccccccc", 1)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "acacacacacacacacacacacacacacacac", 2)).
 					Add(digest.MustNewDigest("instance", remoteexecution.DigestFunction_MD5, "bcbcbcbcbcbcbcbcbcbcbcbcbcbcbcbc", 2)).


### PR DESCRIPTION
> [!NOTE]
> This PR was authored with AI assistance and reviewed by me before opening.

Four small allocation/CPU fixes on the digest, buffer, and key-location-map hot paths. Each commit is independent and explains its own win; this is the summary.

**`digest: avoid fmt.Sprintf in newDigestUnchecked`** — every digest constructed from a proto goes through this. `fmt.Sprintf` parses the format string and reflects on its arguments at runtime; replacing it with a pre-sized `[]byte` + `strconv.AppendInt` is ~3.5× faster per call (76.9 → 22.1 ns). Output is byte-identical, including two-digit enum values.

**`digest: pre-size SetBuilder map and use slices.SortFunc`** — `NewSetBuilder()` now takes a capacity argument so callers can pre-size the backing map. Callers that always fill the set to a known size (request parsing, per-directory file sets, the completeness checker's bounded queue, per-shard partitions) pass that size; callers that build a result of unknown size — chiefly the `missing` set returned by `FindMissing`, where the count depends on the caller's hit rate — pass zero, since pre-allocating the worst case would waste memory and CPU on the common high-hit-rate path. Also replaces `sort.Sort` (interface dispatch per comparison) with `slices.SortFunc`. Sort order unchanged.

**`blobstore/buffer: pre-allocate ToByteSlice result instead of io.ReadAll`** — both `ToByteSlice` implementations know the blob size but used `io.ReadAll`, which append-doubles from 512 bytes (≈2N transient bytes, ~N redundant memcpy). Pre-allocate and `io.ReadFull` instead, matching what `toByteSliceViaChunkReader` already does. Zero-byte blobs need a single explicit `Read()` to drive the validating reader since `io.ReadFull` won't issue one for an empty buffer. Slight behavior change for non-empty blobs: a short read now returns `io.ErrUnexpectedEOF` instead of silently returning a truncated slice — on this path the size is trusted, so a short read indicates a corrupted backend and erroring seems more correct, but flagging it.

**`blobstore/local: share a sentinel error for key-location map misses`** — `hashingKeyLocationMap.Get()` constructed a fresh `status.Error(codes.NotFound, …)` on every lookup miss. Since `Get()` runs once per digest in `FindMissing()`, a CPU profile shows it accounting for ~8% of total CPU at a 50% hit rate. Replaced with a package-level sentinel; every caller only inspects `status.Code()`, never the message or error identity.

Measured against a real `bb_storage` binary on localhost (in-memory and file-backed-mmap CAS configs), driven by a load generator over gRPC, 3 interleaved A/B runs per workload, mean ±σ:

| workload | baseline | patched | Δ |
|---|---|---|---|
| `FindMissingBlobs`, 2000 dig/RPC, 1% miss, in-memory CAS | 1157K ±25K dig/s | 1347K ±9K dig/s | +16.4% |
| `FindMissingBlobs`, 2000 dig/RPC, 50% miss, in-memory CAS | 974K ±6K dig/s | 1136K ±6K dig/s | +16.6% |
| `FindMissingBlobs`, 2000 dig/RPC, 99% miss, in-memory CAS | 881K ±5K dig/s | 1040K ±2K dig/s | +18.1% |
| `BatchReadBlobs`, 200×64 KiB/RPC, file-backed CAS | 1965 ±10 MB/s | 2400 ±6 MB/s | +22.2% |
| `BatchReadBlobs`, 200×64 KiB/RPC, in-memory CAS | 2761 ±50 MB/s | 2798 ±21 MB/s | +1.4% |

The `FindMissingBlobs` win is consistent across the full range of miss rates (1% → 99% all show +15–19%, p50 latency −13–16%) — the sentinel error matters more at higher miss rates while the digest/SetBuilder changes are constant. The in-memory `BatchReadBlobs` row barely moves because in-memory blocks return zero-copy `[]byte` slices, so the `io.ReadAll` path never executes there. The file-backed config (which I think is closer to a typical deployment) is where the buffer fix lands.

`pprof` allocation diff over the file-backed read benchmark shows `io.ReadAll`'s contribution dropping from ~110 GB to zero, and `runtime.memmove` flat CPU dropping from 11.0% to 4.4%.

> [!NOTE]
> The `digest: add test coverage` commit pins the digest string encoding for size 0, `math.MaxInt64`, and an empty instance name, plus tests for `NewSetBuilder()` capacity and `Build()` ordering.
