### PR TITLE
Don't interpret unix.Pwrite()'s return value in case of errors

### DIFF
--- a/pkg/blockdevice/memory_mapped_block_device_unix.go
+++ b/pkg/blockdevice/memory_mapped_block_device_unix.go
@@ -78,10 +78,10 @@ func (bd *memoryMappedBlockDevice) WriteAt(p []byte, off int64) (int, error) {
 	nTotal := 0
 	for len(p) > 0 {
 		n, err := unix.Pwrite(bd.fd, p, off)
-		nTotal += n
 		if err != nil {
 			return nTotal, err
 		}
+		nTotal += n
 		p = p[n:]
 		off += int64(n)
 	}


### PR DESCRIPTION
The way pwrite() is defined in POSIX, there is no mechanism for returning both a size and an error. It's only either one of those. It looks like golang.org/x/sys does not explicitly return a length of zero in case of errors.

Reported by: Gregory Giecold in #159