### PR TITLE
fix: use unix.O_RDONLY in darwin oflagsearch

### DIFF
--- a/pkg/filesystem/local_directory_darwin.go
+++ b/pkg/filesystem/local_directory_darwin.go
@@ -16,7 +16,7 @@ import (
 // rawDeviceNumber is the equivalent of POSIX dev_t.
 type rawDeviceNumber = int32
 
-const oflagSearch = unix.O_SEARCH
+const oflagSearch = unix.O_RDONLY
 
 func (localDirectory) Mknod(name path.Component, perm os.FileMode, deviceNumber DeviceNumber) error {
 	return status.Error(codes.Unimplemented, "Creation of device nodes is not supported on Darwin")


### PR DESCRIPTION
`O_SEARCH` and `O_PATH` give search-only directory permissions on FreeBSD and Linux OS respectively (NB. for Linux this is more restrictive - the handle produced cannot be used for any regular R/W/IO).

`O_SEARCH` is not supported by darwin, so `unix.O_SEARCH` does not exist for darwin build tags in Go; its presence caused a compile failure when attempting to build bb-storage for macOS.

This PR therefore changes the flag to `O_RDONLY` which although is more permissive (it grants search and read access) is the closest equivalent.