### PR TITLE
Actually build for linux_386 in CI

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,6 +2,7 @@ run --workspace_status_command="bash tools/workspace-status.sh"
 common --enable_platform_specific_config
 common --@protobuf//bazel/toolchains:prefer_prebuilt_protoc
 common --protocopt=--fatal_warnings
+common --host_platform=//tools/platforms:host
 
 # Required to make protobuf compile on Windows
 common:windows --host_cxxopt=/std:c++17 --define=protobuf_allow_msvc=true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_amd64'",
                "name": "linux_amd64: build${{ matrix.host.platform_name == 'linux_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64 //..."
             },
             {
                "if": "matrix.host.upload",
@@ -96,7 +96,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_amd64_v3'",
                "name": "linux_amd64_v3: build${{ matrix.host.platform_name == 'linux_amd64_v3' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64_v3' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64_v3 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64_v3' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64_v3 //..."
             },
             {
                "if": "matrix.host.upload",
@@ -171,7 +171,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_386'",
                "name": "linux_386: build${{ matrix.host.platform_name == 'linux_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_386 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_386 //..."
             },
             {
                "if": "matrix.host.upload",
@@ -246,7 +246,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_arm'",
                "name": "linux_arm: build${{ matrix.host.platform_name == 'linux_arm' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm //..."
             },
             {
                "if": "matrix.host.upload",
@@ -321,7 +321,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_arm64'",
                "name": "linux_arm64: build${{ matrix.host.platform_name == 'linux_arm64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm64 //..."
             },
             {
                "if": "matrix.host.upload",
@@ -396,7 +396,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'darwin_amd64'",
                "name": "darwin_amd64: build${{ matrix.host.platform_name == 'darwin_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'darwin_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'darwin_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_amd64 //..."
             },
             {
                "if": "matrix.host.upload",
@@ -471,7 +471,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'darwin_arm64'",
                "name": "darwin_arm64: build${{ matrix.host.platform_name == 'darwin_arm64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'darwin_arm64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_arm64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'darwin_arm64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_arm64 //..."
             },
             {
                "if": "matrix.host.upload",
@@ -546,7 +546,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'freebsd_amd64'",
                "name": "freebsd_amd64: build${{ matrix.host.platform_name == 'freebsd_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'freebsd_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:freebsd_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'freebsd_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:freebsd_amd64 //..."
             },
             {
                "if": "matrix.host.upload",
@@ -621,7 +621,7 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'windows_amd64'",
                "name": "windows_amd64: build${{ matrix.host.platform_name == 'windows_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'windows_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:windows_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'windows_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:windows_amd64 //..."
             },
             {
                "if": "matrix.host.upload",

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -21,47 +21,47 @@
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_amd64'",
                "name": "linux_amd64: build${{ matrix.host.platform_name == 'linux_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64 //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_amd64_v3'",
                "name": "linux_amd64_v3: build${{ matrix.host.platform_name == 'linux_amd64_v3' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64_v3' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64_v3 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64_v3' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_amd64_v3 //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_386'",
                "name": "linux_386: build${{ matrix.host.platform_name == 'linux_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_386 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_386 //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_arm'",
                "name": "linux_arm: build${{ matrix.host.platform_name == 'linux_arm' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'linux_arm64'",
                "name": "linux_arm64: build${{ matrix.host.platform_name == 'linux_arm64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'linux_arm64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:linux_arm64 //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'darwin_amd64'",
                "name": "darwin_amd64: build${{ matrix.host.platform_name == 'darwin_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'darwin_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'darwin_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_amd64 //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'darwin_arm64'",
                "name": "darwin_arm64: build${{ matrix.host.platform_name == 'darwin_arm64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'darwin_arm64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_arm64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'darwin_arm64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:darwin_arm64 //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'freebsd_amd64'",
                "name": "freebsd_amd64: build${{ matrix.host.platform_name == 'freebsd_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'freebsd_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:freebsd_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'freebsd_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:freebsd_amd64 //..."
             },
             {
                "if": "matrix.host.cross_compile || matrix.host.platform_name == 'windows_amd64'",
                "name": "windows_amd64: build${{ matrix.host.platform_name == 'windows_amd64' && ' and test' || '' }}",
-               "run": "bazel ${{ matrix.host.platform_name == 'windows_amd64' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:windows_amd64 --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..."
+               "run": "bazel ${{ matrix.host.platform_name == 'windows_amd64' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:windows_amd64 //..."
             }
          ],
          "strategy": {

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,8 @@ bazel_dep(name = "rules_nodejs", version = "6.7.4")
 bazel_dep(name = "rules_shell", version = "0.8.0")
 bazel_dep(name = "toolchains_llvm", version = "1.7.0")
 
+register_toolchains("//tools/platforms:test_toolchain_running_linux_x86_32_on_x86_64")
+
 git_override(
     module_name = "bazel_remote_apis",
     commit = "becdd8f9ff811df88a22d3eadd6341753d51d167",

--- a/tools/github_workflows/workflows_template.libsonnet
+++ b/tools/github_workflows/workflows_template.libsonnet
@@ -84,7 +84,7 @@
         [{
           name: platform.name + ": build${{ matrix.host.platform_name == '%s' && ' and test' || '' }}" % std.get(platform, 'testPlatform', platform.name),
           // Run tests only if we're not cross-compiling.
-          run: "bazel ${{ matrix.host.platform_name == '%s' && 'test --test_output=errors' || 'build --platforms=@com_github_buildbarn_bb_storage//tools/platforms:%s --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} //..." % [
+          run: "bazel ${{ matrix.host.platform_name == '%s' && 'test --test_output=errors' || 'build --@bazel_tools//tools/test:incompatible_use_default_test_toolchain=False' }} --platforms=@com_github_buildbarn_bb_storage//tools/platforms:%s //..." % [
             std.get(platform, 'testPlatform', platform.name),
             platform.name + if enableCgo then '_cgo' else '',
           ],

--- a/tools/platforms/BUILD.bazel
+++ b/tools/platforms/BUILD.bazel
@@ -26,3 +26,37 @@ platform(
     parents = ["@rules_go//go/toolchain:linux_amd64"],
     visibility = ["//visibility:public"],
 )
+
+platform(
+    name = "host",
+    constraint_values = [
+        # If any of the @rules_go//go/toolchain:rules_go platforms above are
+        # used as target platform under `bazel test`,
+        # @bazel_tools//tools/test:default_test_toolchain does not match the
+        # default @platforms//host as execution platform because it is missing
+        # @rules_go//go/toolchain:cgo_off constraint.
+        #
+        # See also https://github.com/bazelbuild/bazel/issues/30560.
+        "@rules_go//go/toolchain:cgo_off",
+    ],
+    # The host is not remote.
+    exec_properties = {"no-remote-exec": "true"},
+    parents = ["@platforms//host"],
+    visibility = ["//visibility:public"],
+)
+
+# x86_32 binaries can run on x86_64, at least for Linux.
+toolchain(
+    name = "test_toolchain_running_linux_x86_32_on_x86_64",
+    exec_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_32",
+    ],
+    toolchain = "@bazel_tools//tools/test:empty_toolchain",
+    toolchain_type = "@bazel_tools//tools/test:default_test_toolchain_type",
+    visibility = ["//visibility:private"],
+)


### PR DESCRIPTION
Add the `--platforms` argument for `bazel test`. It is possible to build for `linux_386` and run the test on the host platform `linux_amd64`.