### PR TITLE
Stamp image tags from STABLE_ status keys

### DIFF
--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -8,7 +8,7 @@ load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 expand_template(
     name = "stamped_tags",
     out = "_stamped.tags.txt",
-    stamp_substitutions = {"_TAG_": "{{BUILD_SCM_TIMESTAMP}}-{{BUILD_SCM_REVISION}}"},
+    stamp_substitutions = {"_TAG_": "{{STABLE_BUILD_SCM_TIMESTAMP}}-{{STABLE_BUILD_SCM_REVISION}}"},
     substitutions = {"_TAG_": "0.0.0"},
     template = ["_TAG_"],
     visibility = ["//visibility:public"],

--- a/tools/workspace-status.sh
+++ b/tools/workspace-status.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
 if test "${GITHUB_ACTIONS}" = "true"; then
-  echo "BUILD_SCM_REVISION $(git rev-parse --short HEAD)"
-  echo "BUILD_SCM_TIMESTAMP $(TZ=UTC date --date "@$(git show -s --format=%ct HEAD)" +%Y%m%dT%H%M%SZ)"
+  echo "STABLE_BUILD_SCM_REVISION $(git rev-parse --short HEAD)"
+  echo "STABLE_BUILD_SCM_TIMESTAMP $(TZ=UTC date --date "@$(git show -s --format=%ct HEAD)" +%Y%m%dT%H%M%SZ)"
 fi


### PR DESCRIPTION
Fixes #358.

`BUILD_SCM_REVISION` and `BUILD_SCM_TIMESTAMP` have no `STABLE_` prefix, so Bazel files them in `volatile-status.txt` and reports an unchanging digest for that file whatever it contains. The `expand_template` behind `//tools:stamped_tags` is therefore never invalidated, and `_stamped.tags.txt` is generated once and reused indefinitely.

Ephemeral CI never sees this — each job starts with an empty cache, so the action always re-executes. On a build machine whose cache persists, every later build pushes its image to the tag produced by the *first* build on that machine, silently overwriting what was published there before. We hit this on a self-hosted runner: four months of builds published new content to one April tag.

A commit SHA belongs in the stable bucket. It changes rarely, and when it does, artifacts built from it should be rebuilt — which is exactly what the prefix buys.

## Verification

Built `//tools:stamped_tags`, moved HEAD, rebuilt with nothing else touched:

```
build 1: HEAD=0a06012  tag=20260805T153805Z-0a06012
build 2: HEAD=5739b3f  tag=20260805T153820Z-5739b3f
```

The action re-runs and the tag follows the commit. Before this change it stayed frozen at the first value indefinitely.

## Coordination note

`bb-remote-execution`, `bb-remote-asset` and `bb-portal` each ship their own `tools/workspace-status.sh` and consume this template via `--override_module`, so they need the same rename. Until they have it, their builds will emit the literal string `{{STABLE_BUILD_SCM_TIMESTAMP}}-{{STABLE_BUILD_SCM_REVISION}}` as the tag — visibly broken and a failed push, rather than a plausible-looking wrong tag. Happy to send the matching PRs to those repos so they can land together.
