### PR TITLE
feat: respect proxy env vars when `client.Configuration.proxy_from_environment` is set

### DIFF
--- a/pkg/http/client/configuration.go
+++ b/pkg/http/client/configuration.go
@@ -25,12 +25,15 @@ func NewRoundTripperFromConfiguration(configuration *pb.Configuration) (http.Rou
 		ForceAttemptHTTP2: !configuration.GetDisableHttp2(),
 		TLSClientConfig:   tlsConfig,
 	}
-	if proxyURL := configuration.GetProxyUrl(); proxyURL != "" {
-		parsedProxyURL, err := url.Parse(proxyURL)
+	switch proxy := configuration.GetProxy().(type) {
+	case *pb.Configuration_ProxyUrl:
+		parsedProxyURL, err := url.Parse(proxy.ProxyUrl)
 		if err != nil {
 			return nil, util.StatusWrap(err, "Failed to parse proxy URL")
 		}
 		defaultTransport.Proxy = http.ProxyURL(parsedProxyURL)
+	case *pb.Configuration_ProxyFromEnvironment:
+		defaultTransport.Proxy = http.ProxyFromEnvironment
 	}
 	var roundTripper http.RoundTripper = &defaultTransport
 

--- a/pkg/proto/configuration/http/client/client.pb.go
+++ b/pkg/proto/configuration/http/client/client.pb.go
@@ -24,9 +24,13 @@ const (
 )
 
 type Configuration struct {
-	state         protoimpl.MessageState        `protogen:"open.v1"`
-	Tls           *tls.ClientConfiguration      `protobuf:"bytes,1,opt,name=tls,proto3" json:"tls,omitempty"`
-	ProxyUrl      string                        `protobuf:"bytes,2,opt,name=proxy_url,json=proxyUrl,proto3" json:"proxy_url,omitempty"`
+	state protoimpl.MessageState   `protogen:"open.v1"`
+	Tls   *tls.ClientConfiguration `protobuf:"bytes,1,opt,name=tls,proto3" json:"tls,omitempty"`
+	// Types that are valid to be assigned to Proxy:
+	//
+	//	*Configuration_ProxyUrl
+	//	*Configuration_ProxyFromEnvironment
+	Proxy         isConfiguration_Proxy         `protobuf_oneof:"proxy"`
 	AddHeaders    []*Configuration_HeaderValues `protobuf:"bytes,5,rep,name=add_headers,json=addHeaders,proto3" json:"add_headers,omitempty"`
 	DisableHttp2  bool                          `protobuf:"varint,6,opt,name=disable_http2,json=disableHttp2,proto3" json:"disable_http2,omitempty"`
 	Oauth2        *OAuth2Configuration          `protobuf:"bytes,7,opt,name=oauth2,proto3" json:"oauth2,omitempty"`
@@ -71,11 +75,29 @@ func (x *Configuration) GetTls() *tls.ClientConfiguration {
 	return nil
 }
 
+func (x *Configuration) GetProxy() isConfiguration_Proxy {
+	if x != nil {
+		return x.Proxy
+	}
+	return nil
+}
+
 func (x *Configuration) GetProxyUrl() string {
 	if x != nil {
-		return x.ProxyUrl
+		if x, ok := x.Proxy.(*Configuration_ProxyUrl); ok {
+			return x.ProxyUrl
+		}
 	}
 	return ""
+}
+
+func (x *Configuration) GetProxyFromEnvironment() *emptypb.Empty {
+	if x != nil {
+		if x, ok := x.Proxy.(*Configuration_ProxyFromEnvironment); ok {
+			return x.ProxyFromEnvironment
+		}
+	}
+	return nil
 }
 
 func (x *Configuration) GetAddHeaders() []*Configuration_HeaderValues {
@@ -98,6 +120,22 @@ func (x *Configuration) GetOauth2() *OAuth2Configuration {
 	}
 	return nil
 }
+
+type isConfiguration_Proxy interface {
+	isConfiguration_Proxy()
+}
+
+type Configuration_ProxyUrl struct {
+	ProxyUrl string `protobuf:"bytes,2,opt,name=proxy_url,json=proxyUrl,proto3,oneof"`
+}
+
+type Configuration_ProxyFromEnvironment struct {
+	ProxyFromEnvironment *emptypb.Empty `protobuf:"bytes,3,opt,name=proxy_from_environment,json=proxyFromEnvironment,proto3,oneof"`
+}
+
+func (*Configuration_ProxyUrl) isConfiguration_Proxy() {}
+
+func (*Configuration_ProxyFromEnvironment) isConfiguration_Proxy() {}
 
 type OAuth2Configuration struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -329,17 +367,19 @@ var File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_cli
 
 const file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_rawDesc = "" +
 	"\n" +
-	"Pgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\x12#buildbarn.configuration.http.client\x1aEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto\x1a\x1bgoogle/protobuf/empty.proto\"\x89\x03\n" +
+	"Pgithub.com/buildbarn/bb-storage/pkg/proto/configuration/http/client/client.proto\x12#buildbarn.configuration.http.client\x1aEgithub.com/buildbarn/bb-storage/pkg/proto/configuration/tls/tls.proto\x1a\x1bgoogle/protobuf/empty.proto\"\xe4\x03\n" +
 	"\rConfiguration\x12B\n" +
-	"\x03tls\x18\x01 \x01(\v20.buildbarn.configuration.tls.ClientConfigurationR\x03tls\x12\x1b\n" +
-	"\tproxy_url\x18\x02 \x01(\tR\bproxyUrl\x12`\n" +
+	"\x03tls\x18\x01 \x01(\v20.buildbarn.configuration.tls.ClientConfigurationR\x03tls\x12\x1d\n" +
+	"\tproxy_url\x18\x02 \x01(\tH\x00R\bproxyUrl\x12N\n" +
+	"\x16proxy_from_environment\x18\x03 \x01(\v2\x16.google.protobuf.EmptyH\x00R\x14proxyFromEnvironment\x12`\n" +
 	"\vadd_headers\x18\x05 \x03(\v2?.buildbarn.configuration.http.client.Configuration.HeaderValuesR\n" +
 	"addHeaders\x12#\n" +
 	"\rdisable_http2\x18\x06 \x01(\bR\fdisableHttp2\x12P\n" +
 	"\x06oauth2\x18\a \x01(\v28.buildbarn.configuration.http.client.OAuth2ConfigurationR\x06oauth2\x1a>\n" +
 	"\fHeaderValues\x12\x16\n" +
 	"\x06header\x18\x01 \x01(\tR\x06header\x12\x16\n" +
-	"\x06values\x18\x02 \x03(\tR\x06values\"\xb5\x02\n" +
+	"\x06values\x18\x02 \x03(\tR\x06valuesB\a\n" +
+	"\x05proxy\"\xb5\x02\n" +
 	"\x13OAuth2Configuration\x12V\n" +
 	"\x1agoogle_default_credentials\x18\x01 \x01(\v2\x16.google.protobuf.EmptyH\x00R\x18googleDefaultCredentials\x120\n" +
 	"\x13service_account_key\x18\x02 \x01(\tH\x00R\x11serviceAccountKey\x12m\n" +
@@ -376,16 +416,17 @@ var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_cli
 }
 var file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_depIdxs = []int32{
 	4, // 0: buildbarn.configuration.http.client.Configuration.tls:type_name -> buildbarn.configuration.tls.ClientConfiguration
-	3, // 1: buildbarn.configuration.http.client.Configuration.add_headers:type_name -> buildbarn.configuration.http.client.Configuration.HeaderValues
-	1, // 2: buildbarn.configuration.http.client.Configuration.oauth2:type_name -> buildbarn.configuration.http.client.OAuth2Configuration
-	5, // 3: buildbarn.configuration.http.client.OAuth2Configuration.google_default_credentials:type_name -> google.protobuf.Empty
-	2, // 4: buildbarn.configuration.http.client.OAuth2Configuration.client_credentials:type_name -> buildbarn.configuration.http.client.OAuth2ClientCredentials
-	0, // 5: buildbarn.configuration.http.client.OAuth2ClientCredentials.http_client:type_name -> buildbarn.configuration.http.client.Configuration
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	5, // 1: buildbarn.configuration.http.client.Configuration.proxy_from_environment:type_name -> google.protobuf.Empty
+	3, // 2: buildbarn.configuration.http.client.Configuration.add_headers:type_name -> buildbarn.configuration.http.client.Configuration.HeaderValues
+	1, // 3: buildbarn.configuration.http.client.Configuration.oauth2:type_name -> buildbarn.configuration.http.client.OAuth2Configuration
+	5, // 4: buildbarn.configuration.http.client.OAuth2Configuration.google_default_credentials:type_name -> google.protobuf.Empty
+	2, // 5: buildbarn.configuration.http.client.OAuth2Configuration.client_credentials:type_name -> buildbarn.configuration.http.client.OAuth2ClientCredentials
+	0, // 6: buildbarn.configuration.http.client.OAuth2ClientCredentials.http_client:type_name -> buildbarn.configuration.http.client.Configuration
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() {
@@ -394,6 +435,10 @@ func init() {
 func file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_init() {
 	if File_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto != nil {
 		return
+	}
+	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[0].OneofWrappers = []any{
+		(*Configuration_ProxyUrl)(nil),
+		(*Configuration_ProxyFromEnvironment)(nil),
 	}
 	file_github_com_buildbarn_bb_storage_pkg_proto_configuration_http_client_client_proto_msgTypes[1].OneofWrappers = []any{
 		(*OAuth2Configuration_GoogleDefaultCredentials)(nil),

--- a/pkg/proto/configuration/http/client/client.proto
+++ b/pkg/proto/configuration/http/client/client.proto
@@ -13,8 +13,17 @@ message Configuration {
   // certificate will be used when left unset.
   buildbarn.configuration.tls.ClientConfiguration tls = 1;
 
-  // If set, forward all traffic through a proxy with a given URL.
-  string proxy_url = 2;
+  oneof proxy {
+    // If set, forward all traffic through a proxy with a given URL.
+    string proxy_url = 2;
+
+    // If set, use the proxy for a given request, as indicated by the
+    // environment variables http_proxy, https_proxy and no_proxy (or
+    // the uppercase versions thereof). Requests use the proxy from the
+    // environment variable matching their scheme, unless excluded by
+    // no_proxy.
+    google.protobuf.Empty proxy_from_environment = 3;
+  }
 
   message HeaderValues {
     string header = 1;


### PR DESCRIPTION
This matches the [behavior of `http.DefaultTransport`][def-trans] and results in environment variables `$http_proxy`, `$https_proxy`, and `$no_proxy` (and their uppercase counterparts) being consulted to determine which proxy to use/whether to use a proxy for a given URL.

Docs for `ProxyFromEnvironment` are [here][proxy-from-env-doc], source code is [here][src1], [here][src2], and [here][src3].

[def-trans]: https://github.com/golang/go/blob/61b3e65bd2216be76f6208864f84ae184b29ae37/src/net/http/transport.go#L49
[proxy-from-env-doc]: https://pkg.go.dev/net/http#ProxyFromEnvironment

[src1]: https://github.com/golang/go/blob/ebe55c0c38935b39778c38ec8edb1b03c4e96058/src/net/http/transport.go#L501-L520
[src2]: https://github.com/golang/go/blob/ebe55c0c38935b39778c38ec8edb1b03c4e96058/src/net/http/transport.go#L1003-L1015
[src3]: https://github.com/golang/net/blob/eda109f56e86afc41ee941c810e5e4e49f901ec3/http/httpproxy/proxy.go

## motivation

I'm deploying `bb-remote-asset` in an environment where external network access is restricted and must go through proxies, like so:
```bash
export http_proxy=http://proxy.acme.com:100  # route external HTTP traffic via this proxy
export https_proxy=http://proxy.acme.com:200 # likewise, but for HTTPS traffic
export no_proxy=internal.acme.com            # however some domains are exempt and cannot
                                             # be routed through the proxies
```

As far as I can tell it isn't possible to express the above (different proxy URLs for http and https; domain patterns that are exempt from proxying) via `http.client.Configuration.proxy_url` [^workarounds].

[^workarounds]:
    If I understand correctly it is possible to workaround this by having `bb-remote-asset` download assets via RE actions (`FetcherConfiguration.remote_execution`) or by pointing `bb-remote-asset` at a "wrapper" proxy server in a sidecar that consults `$http_proxy`/`$no_proxy`/etc — however, if possible, I'd prefer to have this be handled directly in `bb-remote-asset`

## open questions

~~As written, this PR changes `http.client.NewRoundTripperFromConfiguration` to consult the proxy envivonment variables by default (i.e. when `http.client.Configuration.proxy_url` is not set).~~

~~If this is undesirable (or seems like a potentially confusing/breaking change) I can update this PR to make this behavior opt-in (and mutually exclusive w/`proxy_url`).~~

EDIT: see below